### PR TITLE
Correct python executable name

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -78,7 +78,7 @@ are written in a Python variant).
     # run the script
     hello_world = Process(
       name = 'hello_world',
-      cmdline = 'python2.6 hello_world.py')
+      cmdline = 'python hello_world.py')
 
     # describe the task
     hello_world_task = SequentialTask(


### PR DESCRIPTION
Should be just "python" not "python2.6" -- the vagrant machines don't have a python2.6
