### PR TITLE
Use chmod+x to make termos_runner.pex executable

### DIFF
--- a/src/main/python/apache/aurora/executor/thermos_task_runner.py
+++ b/src/main/python/apache/aurora/executor/thermos_task_runner.py
@@ -19,13 +19,12 @@ import signal
 import socket
 import struct
 import subprocess
-import sys
 import threading
 import time
 
 from mesos.interface import mesos_pb2
 from twitter.common import log
-from twitter.common.dirutil import safe_mkdtemp
+from twitter.common.dirutil import chmod_plus_x, safe_mkdtemp
 from twitter.common.log.options import LogOptions
 from twitter.common.quantity import Amount, Time
 
@@ -253,7 +252,7 @@ class ThermosTaskRunner(TaskRunner):
     if getpass.getuser() == 'root' and self._role:
       params.update(setuid=self._role)
 
-    cmdline_args = [sys.executable, self._runner_pex]
+    cmdline_args = [self._runner_pex]
     cmdline_args.extend(
         '--%s=%s' % (flag, value) for flag, value in params.items() if value is not None)
     if self._enable_chroot:
@@ -268,6 +267,12 @@ class ThermosTaskRunner(TaskRunner):
   def start(self, timeout=MAX_WAIT):
     """Fork the task runner and return once the underlying task is running, up to timeout."""
     self.forking.set()
+
+    try:
+      chmod_plus_x(self._runner_pex)
+    except OSError as e:
+      if e.errno != errno.EPERM:
+        raise TaskError('Failed to chmod +x runner: %s' % e)
 
     self._monitor = TaskMonitor(self._checkpoint_root, self._task_id)
 


### PR DESCRIPTION
When using `--executor_environment_variables` without explicitely passing LD_LIBRARY_PATH, `sys.executable` returns an empty string resulting in a _'[Errno 13] Permission denied'_ error for every launched task.

Moreover, it seems that this feature is coming in 0.30: "Executors no longer inherit environment variables from the agent".

This patch partially revert back 07ce21d where chmod_x method was removed in favor of using sys.executable.

---

Please let me know if the patch seems consistent and if I should post a review on apache.org.