### PR TITLE
Manually configure the private network interface

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,7 +28,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box_version = "0.0.9"
 
   config.vm.define "devcluster" do |dev|
-    dev.vm.network :private_network, ip: "192.168.33.7"
+    dev.vm.network :private_network, ip: "192.168.33.7", :auto_config => false
+    dev.vm.provision "shell", run: "always", inline: "ifconfig eth1 192.168.33.7 netmask 255.255.255.0 up"
     dev.vm.provider :virtualbox do |vb|
       vb.customize ["modifyvm", :id, "--memory", "3072"]
       vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]


### PR DESCRIPTION
I am not sure of the specifics of why this happens but on vagrant 1.8.6 the network interface does not come up correctly and the private_network is attached to the `eth0` nat interface rather than the host-only interface. I tried a number of different parameters but none of them were able to configure the network appropriately. This change manually configures the static ip so that it is connected to the correct adapter. Without this change I could not access the aurora web interface when running `vagrant up`