### PR TITLE
Fix bug. Do not increase current_consecutive_successes if .healthchec…

### DIFF
--- a/src/main/python/apache/aurora/executor/common/health_checker.py
+++ b/src/main/python/apache/aurora/executor/common/health_checker.py
@@ -160,6 +160,11 @@ class ThreadedHealthChecker(ExceptionalThread):
         self.healthy = False
         self.reason = reason
     else:
+      if self.snoozed:
+        log.debug('Reset consecutive successes counter.')
+        self.current_consecutive_successes = 0
+        return
+
       self.current_consecutive_successes += 1
 
       if not self.running:


### PR DESCRIPTION
The Health Check is succeeding when the .healthchecksnooze is present. But it should just snooze which means there shouldn't be any increase in consecutive successes or consecutive failures. 