### PR TITLE
 Fix sandbox permission errors with Mesos 1.6.0 

### DIFF
--- a/src/main/python/apache/aurora/executor/common/sandbox.py
+++ b/src/main/python/apache/aurora/executor/common/sandbox.py
@@ -71,34 +71,35 @@ class SandboxProvider(Interface):
 
 
 class DefaultSandboxProvider(SandboxProvider):
-  SANDBOX_NAME = 'sandbox'
   MESOS_DIRECTORY_ENV_VARIABLE = 'MESOS_DIRECTORY'
 
   def from_assigned_task(self, assigned_task, **kwargs):
-    sandbox_root = os.path.join(os.environ[self.MESOS_DIRECTORY_ENV_VARIABLE], self.SANDBOX_NAME)
+    mesos_dir = os.environ[self.MESOS_DIRECTORY_ENV_VARIABLE]
 
     container = assigned_task.task.container
     if container.docker:
-      return DockerDirectorySandbox(sandbox_root, **kwargs)
+      return DockerDirectorySandbox(mesos_dir, **kwargs)
     elif container.mesos and container.mesos.image:
       return FileSystemImageSandbox(
-          sandbox_root,
+          mesos_dir,
           user=self._get_sandbox_user(assigned_task),
           **kwargs)
     else:
-      return DirectorySandbox(sandbox_root, user=self._get_sandbox_user(assigned_task), **kwargs)
+      return DirectorySandbox(mesos_dir, user=self._get_sandbox_user(assigned_task), **kwargs)
 
 
 class DirectorySandbox(SandboxInterface):
   """ Basic sandbox implementation using a directory on the filesystem """
 
-  def __init__(self, root, user=getpass.getuser(), **kwargs):
-    self._root = root
+  SANDBOX_NAME = 'sandbox'
+
+  def __init__(self, mesos_dir, user=getpass.getuser(), **kwargs):
+    self._mesos_dir = mesos_dir
     self._user = user
 
   @property
   def root(self):
-    return self._root
+    return os.path.join(self._mesos_dir, self.SANDBOX_NAME)
 
   @property
   def container_root(self):
@@ -154,26 +155,24 @@ class DirectorySandbox(SandboxInterface):
 class DockerDirectorySandbox(DirectorySandbox):
   """ A sandbox implementation that configures the sandbox correctly for docker containers. """
 
-  def __init__(self, root, **kwargs):
-    self._mesos_host_sandbox = os.environ[DefaultSandboxProvider.MESOS_DIRECTORY_ENV_VARIABLE]
-
+  def __init__(self, mesos_dir, **kwargs):
     # remove the user value from kwargs if it was set.
     kwargs.pop('user', None)
 
-    super(DockerDirectorySandbox, self).__init__(root, user=None, **kwargs)
+    super(DockerDirectorySandbox, self).__init__(mesos_dir, user=None, **kwargs)
 
   def _create_symlinks(self):
     # This sets up the container to have a similar directory structure to the host.
-    # It takes self._mesos_host_sandbox (e.g. "[exec-root]/runs/RUN1/") and:
+    # It takes self._mesos_dir (e.g. "[exec-root]/runs/RUN1/") and:
     #   - Sets mesos_host_sandbox_root = "[exec-root]/runs/" (one level up from mesos_host_sandbox)
     #   - Creates mesos_host_sandbox_root (recursively)
-    #   - Symlinks _mesos_host_sandbox -> $MESOS_SANDBOX (typically /mnt/mesos/sandbox)
+    #   - Symlinks self._mesos_dir -> $MESOS_SANDBOX (typically /mnt/mesos/sandbox)
     # $MESOS_SANDBOX is provided in the environment by the Mesos containerizer.
 
-    mesos_host_sandbox_root = os.path.dirname(self._mesos_host_sandbox)
+    mesos_host_sandbox_root = os.path.dirname(self._mesos_dir)
     try:
       safe_mkdir(mesos_host_sandbox_root)
-      os.symlink(os.environ['MESOS_SANDBOX'], self._mesos_host_sandbox)
+      os.symlink(os.environ['MESOS_SANDBOX'], self._mesos_dir)
     except (IOError, OSError) as e:
       raise self.CreationError('Failed to create the sandbox root: %s' % e)
 
@@ -195,10 +194,8 @@ class FileSystemImageSandbox(DirectorySandbox):
   # already exists.
   _USER_OR_GROUP_NAME_EXISTS = 9
 
-  def __init__(self, root, **kwargs):
-    self._task_fs_root = os.path.join(
-        os.environ[DefaultSandboxProvider.MESOS_DIRECTORY_ENV_VARIABLE],
-        TASK_FILESYSTEM_MOUNT_POINT)
+  def __init__(self, mesos_dir, **kwargs):
+    self._task_fs_root = os.path.join(mesos_dir, TASK_FILESYSTEM_MOUNT_POINT)
 
     self._no_create_user = kwargs.pop('no_create_user', False)
     self._mounted_volume_paths = kwargs.pop('mounted_volume_paths', None)
@@ -208,7 +205,7 @@ class FileSystemImageSandbox(DirectorySandbox):
       raise self.Error(
           'Failed to initialize FileSystemImageSandbox: no value specified for sandbox_mount_point')
 
-    super(FileSystemImageSandbox, self).__init__(root, **kwargs)
+    super(FileSystemImageSandbox, self).__init__(mesos_dir, **kwargs)
 
   def _verify_group_match_in_taskfs(self, group_id, group_name):
     try:

--- a/src/main/python/apache/aurora/executor/thermos_task_runner.py
+++ b/src/main/python/apache/aurora/executor/thermos_task_runner.py
@@ -239,7 +239,6 @@ class ThermosTaskRunner(TaskRunner):
 
   def _cmdline(self):
     params = dict(log_dir=LogOptions.log_dir(),
-                  log_to_disk='DEBUG',
                   checkpoint_root=self._checkpoint_root,
                   sandbox=self._sandbox.root,
                   container_sandbox=self._sandbox.container_root,

--- a/src/main/python/apache/thermos/core/process.py
+++ b/src/main/python/apache/thermos/core/process.py
@@ -290,7 +290,7 @@ class ProcessBase(object):
       try:
         self.execute()
       except Exception as e:
-        self._log('Error trying to execute %s: %s' % (self._name, e))
+        self._log('Error trying to execute %s: %s' % (self._name, e), exc_info=True)
         raise e
       finally:
         self._ckpt.close()

--- a/src/main/python/apache/thermos/runner/thermos_runner.py
+++ b/src/main/python/apache/thermos/runner/thermos_runner.py
@@ -21,6 +21,7 @@ import sys
 import traceback
 
 from twitter.common import app, log
+from twitter.common.log.options import LogOptions
 
 from apache.thermos.common.excepthook import ExceptionTerminationHandler
 from apache.thermos.common.options import add_port_to
@@ -264,6 +265,9 @@ def proxy_main(args, opts):
 def main(args, opts):
   return proxy_main(args, opts)
 
+
+LogOptions.set_simple(True)
+LogOptions.set_disk_log_level('DEBUG')
 
 app.register_module(ExceptionTerminationHandler())
 app.main()

--- a/src/test/python/apache/aurora/executor/common/test_sandbox.py
+++ b/src/test/python/apache/aurora/executor/common/test_sandbox.py
@@ -71,7 +71,8 @@ def test_create(chmod, chown, getpwnam, getgrgid):
   getpwnam.assert_called_with('cletus')
   getgrgid.assert_called_with(123)
 
-  chown.assert_called_with(ds.root, 456, 123)
+  chown.assert_any_call(mesos_dir, 456, 123)
+  chown.assert_any_call(ds.root, 456, 123)
   chmod.assert_called_with(ds.root, 0700)
 
 

--- a/src/test/sh/org/apache/aurora/e2e/test_end_to_end.sh
+++ b/src/test/sh/org/apache/aurora/e2e/test_end_to_end.sh
@@ -531,7 +531,9 @@ test_scp_permissions() {
   # Unset because we are expecting an error
   set +e
 
-  _sandbox_contents=$(aurora task scp $_filename ${_jobkey}:../ 2>&1 > /dev/null)
+  # $_filename is a path relative to "/var/lib/mesos/slaves/x/frameworks/y/executors/z/runs/latest/sandbox".
+  # We shouldn't have write permissions outside of the "/latest" executor scratch dir created by Mesos.
+  _sandbox_contents=$(aurora task scp $_filename ${_jobkey}:../../ 2>&1 > /dev/null)
   _retcode=$?
 
   # Reset -e after command has been run


### PR DESCRIPTION
This change makes Aurora compatible with Mesos 1.6.0 which has changed the permission of sandbox folders (see https://issues.apache.org/jira/browse/MESOS-8332).

Please have a look at the individual commits for further details and descriptions.