### PR TITLE
Removing MD5 checksum and making SHA-512 our default release checksum

### DIFF
--- a/build-support/release/release-candidate
+++ b/build-support/release/release-candidate
@@ -228,7 +228,6 @@ pushd ${dist_dir}
 
   # Create the checksums
   echo "Creating checksums"
-  gpg --print-md MD5 ${dist_name}.tar.gz > ${dist_name}.tar.gz.md5
   shasum -a 512 ${dist_name}.tar.gz > ${dist_name}.tar.gz.sha512
 popd
 
@@ -293,8 +292,8 @@ ${aurora_git_web_url};a=shortlog;h=refs/tags/${rc_version_tag}
 The release candidate is available at:
 ${aurora_svn_rc_url}/${dist_name}.tar.gz
 
-The MD5 checksum of the release candidate can be found at:
-${aurora_svn_rc_url}/${dist_name}.tar.gz.md5
+The SHA-512 checksum of the release candidate can be found at:
+${aurora_svn_rc_url}/${dist_name}.tar.gz.sha512
 
 The signature of the release candidate can be found at:
 ${aurora_svn_rc_url}/${dist_name}.tar.gz.asc


### PR DESCRIPTION
According to new Apache policy, we should only distribute a SHA-256 or SHA-512 checksum along with new releases.

Removing MD5 hash from releases as required by new Apache policy in preparation for 0.21.0 release.

Making SHA-512 our default checksum for releases.