### PR TITLE
Removing MD5 check from verify release candidate script and release script

### DIFF
--- a/build-support/release/release
+++ b/build-support/release/release
@@ -192,8 +192,7 @@ echo "Signing the distribution"
 gpg --armor --output ${dist_name}.tar.gz.asc --detach-sig ${dist_name}.tar.gz
 
 # Create the checksums
-echo "Creating checksums"
-gpg --print-md MD5 ${dist_name}.tar.gz > ${dist_name}.tar.gz.md5
+echo "Creating checksum"
 shasum -a 512 ${dist_name}.tar.gz > ${dist_name}.tar.gz.sha512
 
 if [[ $publish == 1 ]]; then
@@ -241,8 +240,8 @@ ${aurora_git_web_url}&a=shortlog&h=refs/tags/${current_version_tag}
 The release is available at:
 ${aurora_svn_dist_url}/${current_version}/${dist_name}.tar.gz
 
-The MD5 checksum of the release can be found at:
-${aurora_svn_dist_url}/${current_version}/${dist_name}.tar.gz.md5
+The SHA-512 checksum of the release can be found at:
+${aurora_svn_dist_url}/${current_version}/${dist_name}.tar.gz.sha512
 
 The signature of the release can be found at:
 ${aurora_svn_dist_url}/${current_version}/${dist_name}.tar.gz.asc

--- a/build-support/release/release-candidate
+++ b/build-support/release/release-candidate
@@ -226,8 +226,8 @@ pushd ${dist_dir}
   echo "Signing the distribution"
   gpg --armor --output ${dist_name}.tar.gz.asc --detach-sig ${dist_name}.tar.gz
 
-  # Create the checksums
-  echo "Creating checksums"
+  # Create the checksum
+  echo "Creating checksum"
   shasum -a 512 ${dist_name}.tar.gz > ${dist_name}.tar.gz.sha512
 popd
 

--- a/build-support/release/verify-release-candidate
+++ b/build-support/release/verify-release-candidate
@@ -40,10 +40,8 @@ fetch_archive() {
   local dist_name=$1
   download_rc_file ${dist_name}.tar.gz
   download_rc_file ${dist_name}.tar.gz.asc
-  download_rc_file ${dist_name}.tar.gz.md5
   download_rc_file ${dist_name}.tar.gz.sha512
   gpg --verify ${dist_name}.tar.gz.asc ${dist_name}.tar.gz
-  gpg --print-md MD5 ${dist_name}.tar.gz | diff - ${dist_name}.tar.gz.md5
   shasum -a 512 ${dist_name}.tar.gz | diff - ${dist_name}.tar.gz.sha512
 }
 


### PR DESCRIPTION
No longer needed as Apache policy recommends at least SHA-256