### PR TITLE
Memoize loader.load and loader.load_json

### DIFF
--- a/src/main/python/apache/aurora/client/cli/context.py
+++ b/src/main/python/apache/aurora/client/cli/context.py
@@ -148,7 +148,7 @@ class AuroraCommandContext(Context):
     """Loads a job configuration if provided."""
     return self.get_job_config(jobkey, config_file) if config_file is not None else None
 
-  def get_job_config(self, jobkey, config_file):
+  def get_job_config(self, jobkey, config_file, use_memoized_env=False):
     """Loads a job configuration from a config file."""
     jobname = jobkey.name
     try:
@@ -163,7 +163,8 @@ class AuroraCommandContext(Context):
           self.options.bindings,
           select_cluster=jobkey.cluster,
           select_role=jobkey.role,
-          select_env=jobkey.env)
+          select_env=jobkey.env,
+          use_memoized_env=use_memoized_env)
       check_result = result.raw().check()
       if not check_result.ok():
         raise self.CommandError(EXIT_INVALID_CONFIGURATION, check_result)

--- a/src/main/python/apache/aurora/client/config.py
+++ b/src/main/python/apache/aurora/client/config.py
@@ -186,7 +186,8 @@ def get_config(jobname,
                bindings=(),
                select_cluster=None,
                select_role=None,
-               select_env=None):
+               select_env=None,
+               use_memoized_env=False):
   """Creates and returns a config object contained in the provided file."""
   loader = AnnotatedAuroraConfig.load_json if json else AnnotatedAuroraConfig.load
   return loader(config_file,
@@ -194,4 +195,5 @@ def get_config(jobname,
                 bindings,
                 select_cluster=select_cluster,
                 select_role=select_role,
-                select_env=select_env)
+                select_env=select_env,
+                use_memoized_env=use_memoized_env)

--- a/src/main/python/apache/aurora/client/config.py
+++ b/src/main/python/apache/aurora/client/config.py
@@ -188,6 +188,7 @@ def get_config(jobname,
                select_role=None,
                select_env=None,
                use_memoized_env=False):
+
   """Creates and returns a config object contained in the provided file."""
   loader = AnnotatedAuroraConfig.load_json if json else AnnotatedAuroraConfig.load
   return loader(config_file,

--- a/src/main/python/apache/aurora/config/__init__.py
+++ b/src/main/python/apache/aurora/config/__init__.py
@@ -111,18 +111,18 @@ class AuroraConfig(object):
   @classmethod
   def load(
         cls, filename, name=None, bindings=None,
-        select_cluster=None, select_role=None, select_env=None):
+        select_cluster=None, select_role=None, select_env=None, use_memoized_env=False):
     # TODO(atollenaere): should take a JobKey when non-jobkey interface is deprecated
-    env = AuroraConfigLoader.load(filename)
+    env = AuroraConfigLoader.load(filename, use_memoized_env)
     return cls.apply_plugins(
         cls(cls.pick(env, name, bindings, select_cluster, select_role, select_env)), env)
 
   @classmethod
   def load_json(
         cls, filename, name=None, bindings=None,
-        select_cluster=None, select_role=None, select_env=None):
+        select_cluster=None, select_role=None, select_env=None, use_memoized_env=False):
     # TODO(atollenaere): should take a JobKey when non-jobkey interface is deprecated
-    env = AuroraConfigLoader.load_json(filename)
+    env = AuroraConfigLoader.load_json(filename, use_memoized_env)
     return cls.apply_plugins(
         cls(cls.pick(env, name, bindings, select_cluster, select_role, select_env)), env)
 

--- a/src/main/python/apache/aurora/config/loader.py
+++ b/src/main/python/apache/aurora/config/loader.py
@@ -61,6 +61,16 @@ class AuroraConfigLoader(PystachioConfig):
 
   @classmethod
   def gen_content_key(cls, loadable):
+    """
+    Generates a key for caching from the loadable
+    if supported.
+
+    Currently only FileExecutor and FilelikeExecutors are
+    supported.
+
+    For other loadables, the key will be None which will
+    skip memoizing and reload the configuration each time.
+    """
     key = None
     if FileExecutor.matches(loadable):
       with open(loadable) as fp:

--- a/src/main/python/apache/aurora/config/loader.py
+++ b/src/main/python/apache/aurora/config/loader.py
@@ -22,8 +22,8 @@ from apache.aurora.config.schema import base as base_schema
 
 class AuroraConfigLoader(PystachioConfig):
   SCHEMA_MODULES = []
-  cached_env = dict()
-  cached_json = dict()
+  CACHED_ENV = dict()
+  CACHED_JSON = dict()
 
   @classmethod
   def assembled_schema(cls, schema_modules):
@@ -60,12 +60,12 @@ class AuroraConfigLoader(PystachioConfig):
   @classmethod
   def load(cls, loadable, is_memoized=False):
     env_key = loadable.name if hasattr(loadable, 'name') else loadable
-    if is_memoized and env_key in cls.cached_env:
-      env = cls.cached_env[env_key]
+    if is_memoized and env_key in cls.CACHED_ENV:
+      env = cls.CACHED_ENV[env_key]
     else:
       env = cls.load_raw(loadable).environment
       if is_memoized:
-        cls.cached_env[env_key] = env
+        cls.CACHED_ENV[env_key] = env
     return env
 
   @classmethod
@@ -74,13 +74,13 @@ class AuroraConfigLoader(PystachioConfig):
 
   @classmethod
   def load_json(cls, filename, is_memoized=False):
-    if is_memoized and filename in cls.cached_json:
-      json = cls.cached_json[filename]
+    if is_memoized and filename in cls.CACHED_JSON:
+      json = cls.CACHED_JSON[filename]
     else:
       with open(filename) as fp:
         json = cls.loads_json(fp.read())
       if is_memoized:
-        cls.cached_json[filename] = json
+        cls.CACHED_JSON[filename] = json
     return json
 
   @classmethod

--- a/src/main/python/apache/aurora/config/loader.py
+++ b/src/main/python/apache/aurora/config/loader.py
@@ -14,12 +14,10 @@
 
 import hashlib
 import json
-import os
 import pkgutil
 
 from pystachio.config import Config as PystachioConfig
-from pystachio.compatibility import Compatibility
-
+from pystachio.config import FileExecutor, FilelikeExecutor
 
 from apache.aurora.config.schema import base as base_schema
 
@@ -64,10 +62,10 @@ class AuroraConfigLoader(PystachioConfig):
   @classmethod
   def gen_content_key(cls, loadable):
     key = None
-    if isinstance(loadable, Compatibility.stringy) and os.path.isfile(loadable):
+    if FileExecutor.matches(loadable):
       with open(loadable) as fp:
         key = hashlib.md5(fp.read()).hexdigest()
-    elif hasattr(loadable, 'read') and callable(loadable.read):
+    elif FilelikeExecutor.matches(loadable):
       key = hashlib.md5(loadable.read()).hexdigest()
       loadable.seek(0)
     return key

--- a/src/test/python/apache/aurora/config/BUILD
+++ b/src/test/python/apache/aurora/config/BUILD
@@ -16,6 +16,7 @@ python_tests(
   name = 'config',
   sources = globs('*py'),
   dependencies = [
+    '3rdparty/python:mock',
     '3rdparty/python:requests-mock',
     '3rdparty/python:twitter.common.contextutil',
     'api/src/main/thrift/org/apache/aurora/gen',

--- a/src/test/python/apache/aurora/config/test_loader.py
+++ b/src/test/python/apache/aurora/config/test_loader.py
@@ -73,7 +73,6 @@ jobs = [HELLO_WORLD, OTHERJOB]
 MESOS_CONFIG_MD5 = hashlib.md5(MESOS_CONFIG).hexdigest()
 
 
-
 def test_enoent():
   nonexistent_file = tempfile.mktemp()
   with pytest.raises(AuroraConfigLoader.NotFound):
@@ -194,7 +193,7 @@ def test_load_with_includes():
 def test_memoized_load_cache_hit(mock_gen_content_key):
   expected_env = AuroraConfigLoader.load(BytesIO(MESOS_CONFIG))
   mock_gen_content_key.return_value = MESOS_CONFIG_MD5
-  AuroraConfigLoader.CACHED_ENV = {MESOS_CONFIG_MD5: expected_env }
+  AuroraConfigLoader.CACHED_ENV = {MESOS_CONFIG_MD5: expected_env}
   loaded_env = AuroraConfigLoader.load('a/path', is_memoized=True)
   assert loaded_env == expected_env, "Test cache hit"
 
@@ -203,9 +202,7 @@ def test_memoized_load():
   AuroraConfigLoader.CACHED_ENV = {}
   def check_env(env, config):
     assert 'jobs' in env and len(env['jobs']) == 1, (
-      "Match expected jobs for config=%s, memoized=%s" % (
-        config, is_memoized)
-    )
+      "Match expected jobs for config=%s" % config)
     assert env['jobs'][0].name().get() == 'hello_world'
 
   with temporary_dir() as d:
@@ -221,7 +218,7 @@ def test_memoized_load():
         assert MESOS_CONFIG_MD5 not in AuroraConfigLoader.CACHED_ENV.keys(), (
           "No key is cached when config=%s and is_memoized=False")
 
-        fp.seek(0) #previous load results in filepointer at eof
+        fp.seek(0)  # previous load results in filepointer at eof
         env = AuroraConfigLoader.load(config, is_memoized=True)
         check_env(env, config)
         assert MESOS_CONFIG_MD5 in AuroraConfigLoader.CACHED_ENV.keys(), (

--- a/src/test/python/apache/aurora/config/test_loader.py
+++ b/src/test/python/apache/aurora/config/test_loader.py
@@ -134,7 +134,9 @@ def test_load_json_memoized():
       # verify that value we loaded is the cached value(job[0]) when is_memoized=True
       assert after_overwrite == jobs[0]
       after_overwrite_no_memozied = AuroraConfigLoader.load_json(
-        fp.name, is_memoized=False)['jobs'][0]
+          fp.name,
+          is_memoized=False
+        )['jobs'][0]
       # without memoization, verify that value we load is the uncached value(job[1])
       assert after_overwrite_no_memozied == jobs[1]
 

--- a/src/test/python/apache/aurora/config/test_loader.py
+++ b/src/test/python/apache/aurora/config/test_loader.py
@@ -125,6 +125,16 @@ def test_gen_content_key():
           "check hexdigest for %s" % config)
 
 
+@mock.patch('apache.aurora.config.loader.AuroraConfigLoader.gen_content_key')
+def test_memoized_load_json_cache_hit(mock_gen_content_key):
+  expected_env = AuroraConfigLoader.load(BytesIO(MESOS_CONFIG))
+  expected_job_json = json.dumps(expected_env['jobs'][0].get())
+  mock_gen_content_key.return_value = MESOS_CONFIG_MD5
+  AuroraConfigLoader.CACHED_JSON = {MESOS_CONFIG_MD5: expected_job_json}
+  loaded_job_json = AuroraConfigLoader.load_json('a/path', is_memoized=True)
+  assert loaded_job_json == expected_job_json, "Test cache hit load_json"
+
+
 def test_load_json_memoized():
   AuroraConfigLoader.CACHED_JSON = {}
   env = AuroraConfigLoader.load(BytesIO(MESOS_CONFIG_MULTI))

--- a/src/test/python/apache/aurora/config/test_loader.py
+++ b/src/test/python/apache/aurora/config/test_loader.py
@@ -18,7 +18,7 @@ import tempfile
 from io import BytesIO
 
 import pytest
-from twitter.common.contextutil import temporary_file, temporary_file_path, temporary_dir
+from twitter.common.contextutil import temporary_file, temporary_dir
 
 from apache.aurora.config import AuroraConfig
 from apache.aurora.config.loader import AuroraConfigLoader
@@ -100,6 +100,7 @@ def test_load_json_single():
   new_job = AuroraConfigLoader.loads_json(json.dumps(job.get()))['jobs'][0]
   assert new_job == job
 
+
 def test_load_json_memoized():
   env = AuroraConfigLoader.load(BytesIO(MESOS_CONFIG_MULTI))
   jobs = env['jobs']
@@ -116,7 +117,8 @@ def test_load_json_memoized():
       fp.close()
       after_overwrite = AuroraConfigLoader.load_json(fp.name, is_memoized=True)['jobs'][0]
       assert after_overwrite == jobs[0]
-      after_overwrite_no_memozied = AuroraConfigLoader.load_json(fp.name, is_memoized=False)['jobs'][0]
+      after_overwrite_no_memozied = AuroraConfigLoader.load_json(
+        fp.name, is_memoized=False)['jobs'][0]
       assert after_overwrite_no_memozied == jobs[1]
 
 
@@ -139,6 +141,7 @@ def test_load():
       assert 'jobs' in env and len(env['jobs']) == 1
       hello_world = env['jobs'][0]
       assert hello_world.name().get() == 'hello_world'
+
 
 def test_load_with_includes():
   with temporary_dir() as tmp_dir:
@@ -191,7 +194,6 @@ def test_memoized_load():
         assert 'jobs' in env_no_cache and len(env_no_cache['jobs']) == 2
         other_job = env_no_cache['jobs'][1]
         assert other_job.name().get() == 'otherjob'
-
 
 
 def test_pick():

--- a/src/test/python/apache/aurora/config/test_loader.py
+++ b/src/test/python/apache/aurora/config/test_loader.py
@@ -161,7 +161,7 @@ def test_load_with_includes():
         assert other_job.name().get() == 'otherjob'
 
 
-def test_cached_load():
+def test_memoized_load():
   with temporary_dir() as d:
     with open(os.path.join(d, 'config.aurora'), 'w+') as fp:
       fp.write(MESOS_CONFIG)
@@ -179,18 +179,19 @@ def test_cached_load():
       fp.flush()
       fp.seek(0)
 
-      config = fp.name
-      # Verfiy Cached Content is from initial write/read, (1 job)
-      env = AuroraConfigLoader.load(config, is_memoized=True)
-      assert 'jobs' in env and len(env['jobs']) == 1
-      hello_world = env['jobs'][0]
-      assert hello_world.name().get() == 'hello_world'
+      for config in (fp.name, fp):
+        # Verfiy Cached Content is from initial write/read, (1 job)
+        env = AuroraConfigLoader.load(config, is_memoized=True)
+        assert 'jobs' in env and len(env['jobs']) == 1
+        hello_world = env['jobs'][0]
+        assert hello_world.name().get() == 'hello_world'
 
-      # Verfiy uncached content is from second write, (2 jobs)
-      env_no_cache = AuroraConfigLoader.load(config, is_memoized=False)
-      assert 'jobs' in env_no_cache and len(env_no_cache['jobs']) == 2
-      other_job = env_no_cache['jobs'][1]
-      assert other_job.name().get() == 'otherjob'
+        # Verfiy uncached content is from second write, (2 jobs)
+        env_no_cache = AuroraConfigLoader.load(config, is_memoized=False)
+        assert 'jobs' in env_no_cache and len(env_no_cache['jobs']) == 2
+        other_job = env_no_cache['jobs'][1]
+        assert other_job.name().get() == 'otherjob'
+
 
 
 def test_pick():


### PR DESCRIPTION
Problem: when reusing the aurora.client.cli.context to process multiple jobkeys from a config_file, the client currently reloads and processes the config file for each jobkey. For large complicated aurora files this can take ~40s to process which makes it expensive to do this every time for each jobkey.

Solution: memoize the loader.load() on the config file path so that we only load and process each config file once.

Result:  We only need to load and process each config file once.  For config files with ~50keys and a 40s load time, this significantly reduces the overall time spent inspecting the jobs.