### PR TITLE
Upgrade dev enviornment to Mesos 1.6.1

### DIFF
--- a/3rdparty/python/BUILD
+++ b/3rdparty/python/BUILD
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 
-MESOS_REV = '1.5.0'
+MESOS_REV = '1.6.1'
 
 python_requirement_library(
   name = 'mesos.interface',

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -2,6 +2,7 @@
 ======
 
 ### New/updated:
+- Updated to Mesos 1.6.1.
 - New update strategy added: Variable Batch Update. With this strategy, a job may be updated in
   in batches of different sizes. For example, an update which modifies a total of 10 instances may
   be done in batch sizes of 2, 3, and 5. The number of updated instances must equal the size of the
@@ -13,8 +14,7 @@
   or a `VariableBatchUpdateStrategy` object. `QueueUpdateStrategy` and `BatchUpdateStrategy` take
   a single integer argument while `VariableBatchUpdateStrategy` takes a list of positive integers
   as an argument.
-- Updated to Mesos 1.6.1
-  
+
 ### Deprecations and removals:
 
 - Deprecated use of Thrift fields `JobUpdateSettings.waitForBatchCompletion` and

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -13,7 +13,8 @@
   or a `VariableBatchUpdateStrategy` object. `QueueUpdateStrategy` and `BatchUpdateStrategy` take
   a single integer argument while `VariableBatchUpdateStrategy` takes a list of positive integers
   as an argument.
-
+- Updated to Mesos 1.6.1
+  
 ### Deprecations and removals:
 
 - Deprecated use of Thrift fields `JobUpdateSettings.waitForBatchCompletion` and

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,7 +23,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.hostname = "aurora.local"
   # See build-support/packer/README.md for instructions on updating this box.
   config.vm.box = "apache-aurora/dev-environment"
-  config.vm.box_version = "0.0.16"
+  config.vm.box_version = "0.0.17"
 
   config.vm.define "devcluster" do |dev|
     dev.vm.network :private_network, ip: "192.168.33.7", :auto_config => false

--- a/build-support/packer/build.sh
+++ b/build-support/packer/build.sh
@@ -17,7 +17,7 @@ set -o errexit
 set -o nounset
 set -o verbose
 
-readonly MESOS_VERSION=1.5.0
+readonly MESOS_VERSION=1.6.1
 
 function remove_unused {
   # The default bento/ubuntu-16.04 image includes juju-core, which adds ~300 MB to our image.
@@ -62,14 +62,14 @@ function install_docker {
 }
 
 function install_docker2aci {
-  DOCKER2ACI_VERSION="0.17.1"
-  GOLANG_VERSION="1.9.2"
+  DOCKER2ACI_VERSION="0.17.2"
+  GOLANG_VERSION="1.11"
 
   TEMP_PATH=$(mktemp -d)
   pushd "$TEMP_PATH"
 
   echo "Downloading go..."
-  curl -sL "https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-amd64.tar.gz" | tar -xz
+  curl -sL "https://dl.google.com/go/go${GOLANG_VERSION}.linux-amd64.tar.gz" | tar -xz
 
   export GOROOT="$PWD/go"
   export PATH="$PATH:$GOROOT/bin"

--- a/build.gradle
+++ b/build.gradle
@@ -390,7 +390,7 @@ dependencies {
   compile "org.apache.curator:curator-client:${curatorRev}"
   compile "org.apache.curator:curator-framework:${curatorRev}"
   compile "org.apache.curator:curator-recipes:${curatorRev}"
-  compile 'org.apache.mesos:mesos:1.5.0'
+  compile 'org.apache.mesos:mesos:1.6.1'
   compile "org.asynchttpclient:async-http-client:${asyncHttpclientRev}"
   compile "org.apache.shiro:shiro-guice:${shiroRev}"
   compile "org.apache.shiro:shiro-web:${shiroRev}"

--- a/src/main/python/apache/aurora/executor/common/sandbox.py
+++ b/src/main/python/apache/aurora/executor/common/sandbox.py
@@ -183,7 +183,7 @@ class DockerDirectorySandbox(DirectorySandbox):
       safe_mkdir(mesos_host_sandbox_root)
       os.symlink(os.environ['MESOS_SANDBOX'], self._mesos_dir)
       # Restore permissions to pre Mesos 1.6 levels in order to retain Aurora task ssh
-      # functionality. This directory is bind mounted by Mesos therefore it'll sucessfully
+      # functionality. This directory is bind mounted by Mesos therefore it'll
       # change the permissions on the host.
       os.chmod(os.environ['MESOS_SANDBOX'], 0755)
     except (IOError, OSError) as e:

--- a/src/main/python/apache/aurora/executor/common/sandbox.py
+++ b/src/main/python/apache/aurora/executor/common/sandbox.py
@@ -182,9 +182,11 @@ class DockerDirectorySandbox(DirectorySandbox):
     try:
       safe_mkdir(mesos_host_sandbox_root)
       os.symlink(os.environ['MESOS_SANDBOX'], self._mesos_dir)
-      # Restore permissions to pre Mesos 1.6 levels in order to retain Aurora task ssh
+      # Restore permissions to pre Mesos 1.6.0 levels in order to retain Aurora task ssh
       # functionality. This directory is bind mounted by Mesos therefore it'll
       # change the permissions on the host.
+      # This is necessary since Mesos 1.6.0 (https://issues.apache.org/jira/browse/MESOS-8332).
+      # TODO(rdelvalle): Find a cleaner solution for this problem.
       os.chmod(os.environ['MESOS_SANDBOX'], 0755)
     except (IOError, OSError) as e:
       raise self.CreationError('Failed to create the sandbox root: %s' % e)

--- a/src/main/python/apache/aurora/executor/common/sandbox.py
+++ b/src/main/python/apache/aurora/executor/common/sandbox.py
@@ -182,6 +182,10 @@ class DockerDirectorySandbox(DirectorySandbox):
     try:
       safe_mkdir(mesos_host_sandbox_root)
       os.symlink(os.environ['MESOS_SANDBOX'], self._mesos_dir)
+      # Restore permissions to pre Mesos 1.6 levels in order to retain Aurora task ssh
+      # functionality. This directory is bind mounted by Mesos therefore it'll sucessfully
+      # change the permissions on the host.
+      os.chmod(os.environ['MESOS_SANDBOX'], 0755)
     except (IOError, OSError) as e:
       raise self.CreationError('Failed to create the sandbox root: %s' % e)
 


### PR DESCRIPTION
* Upgraded Mesos dependencies to 1.6.1
* Uploaded apache-aurora/dev-environment 0.0.17 up to Vagrant Cloud
* Upgraded Docker2ACI to latest version.
* Upgraded go to latest version and changed download location to match recent changes by Google.

Mesos Info:
* Mesos 1.6 changelog: https://mesos.apache.org/blog/mesos-1-6-1-released/
* Mesos update instructions: https://mesos.apache.org/documentation/latest/upgrades/#upgrading-from-1-5-x-to-1-6-x

Testing done:
* Ran integration tests