### PR TITLE
Custom executor UI fix

### DIFF
--- a/src/main/java/org/apache/aurora/scheduler/thrift/ReadOnlySchedulerImpl.java
+++ b/src/main/java/org/apache/aurora/scheduler/thrift/ReadOnlySchedulerImpl.java
@@ -171,7 +171,7 @@ class ReadOnlySchedulerImpl implements ReadOnlyScheduler.Iface {
     List<ScheduledTask> tasks = Lists.transform(
         getTasks(query),
         task -> {
-          task.getAssignedTask().getTask().unsetExecutorConfig();
+          task.getAssignedTask().getTask().getExecutorConfig().unsetData();
           return task;
         });
 

--- a/src/test/java/org/apache/aurora/scheduler/thrift/ReadOnlySchedulerImplTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/thrift/ReadOnlySchedulerImplTest.java
@@ -353,9 +353,12 @@ public class ReadOnlySchedulerImplTest extends EasyMockTest {
 
     control.replay();
 
+    TaskConfig taskConfig = defaultTask(true);
+    taskConfig.getExecutorConfig().unsetData();
+
     ImmutableList<ScheduledTask> expected = IScheduledTask.toBuildersList(makeDefaultScheduledTasks(
         10,
-        defaultTask(true).setExecutorConfig(null)));
+        taskConfig));
 
     Response response = assertOkResponse(thrift.getTasksWithoutConfigs(new TaskQuery()));
     assertEquals(expected, response.getResult().getScheduleStatusResult().getTasks());

--- a/ui/src/main/js/components/TaskListItemActions.js
+++ b/ui/src/main/js/components/TaskListItemActions.js
@@ -1,9 +1,18 @@
 import React from 'react';
 
+import { isThermos } from 'utils/Task';
+
 export default function ({ task }) {
-  return (<div className='task-list-item-host'>
-    <a href={`http://${task.assignedTask.slaveHost}:1338/task/${task.assignedTask.taskId}`}>
-      {task.assignedTask.slaveHost}
-    </a>
-  </div>);
+
+  if (isThermos(task.assignedTask.task)) {
+    return (<div className='task-list-item-host'>
+        <a href={`http://${task.assignedTask.slaveHost}:1338/task/${task.assignedTask.taskId}`}>
+    {task.assignedTask.slaveHost}
+  </a>
+    </div>);
+  } else {
+    return (<div className='task-list-item-host'>
+    <strong>{task.assignedTask.slaveHost}</strong>
+    </div>);
+  }
 }

--- a/ui/src/main/js/components/TaskListItemActions.js
+++ b/ui/src/main/js/components/TaskListItemActions.js
@@ -3,16 +3,15 @@ import React from 'react';
 import { isThermos } from 'utils/Task';
 
 export default function ({ task }) {
-
   if (isThermos(task.assignedTask.task)) {
     return (<div className='task-list-item-host'>
-        <a href={`http://${task.assignedTask.slaveHost}:1338/task/${task.assignedTask.taskId}`}>
-    {task.assignedTask.slaveHost}
-  </a>
+      <a href={`http://${task.assignedTask.slaveHost}:1338/task/${task.assignedTask.taskId}`}>
+        {task.assignedTask.slaveHost}
+      </a>
     </div>);
   } else {
     return (<div className='task-list-item-host'>
-    <strong>{task.assignedTask.slaveHost}</strong>
+      <strong>{task.assignedTask.slaveHost}</strong>
     </div>);
   }
 }


### PR DESCRIPTION
With this patch two things are done:
1. The executor name is exposed through the getTasksWithoutConfigs API. This is necessary for the UI to distinguish between Thermos based executors which expect a certain sandbox layout, and non-thermos based executors which do not have this concept.

This adds minimal overhead (in the case of thermos constant overhead) and doesn't reveal any more information than was previously known or obtainable through the getTaskStatus.

2. Renders links to the thermos observer only if the executor used is thermos.
Used a bold tag when non-thermos tasks are rendered for the Mesos agent address in order to maintain UI consistency.

<img width="1143" alt="screen shot 2018-10-10 at 3 17 09 pm" src="https://user-images.githubusercontent.com/1643994/46769348-59e7d780-cca0-11e8-8b6f-2ac956811205.png">
