### PR TITLE
Update Pystachio to 0.8.4

### DIFF
--- a/3rdparty/python/requirements.txt
+++ b/3rdparty/python/requirements.txt
@@ -27,7 +27,7 @@ mox==0.5.3
 pex==1.2.15
 protobuf==3.5.1
 psutil==5.4.3
-pystachio==0.8.3
+pystachio==0.8.4
 requests==2.18.4
 requests-kerberos==0.11.0
 requests-mock==1.3.0

--- a/src/test/python/apache/aurora/config/test_base.py
+++ b/src/test/python/apache/aurora/config/test_base.py
@@ -155,6 +155,20 @@ def test_simple_config():
     assert proxy_config1.ports() == set()
 
 
+def test_schema_equality():
+  one = REIFIED_CONFIG
+  two = REIFIED_CONFIG
+  other = REIFIED_LIMITED_CONFIG
+
+  assert one() == two()
+  assert not one() == other()
+  assert one() != other()
+  assert not one() != two()
+
+  assert one() in {two(): 'foo'}
+  assert one() not in {other(): 'bar'}
+
+
 def make_config(announce, *ports):
   process = Process(
       name='hello',


### PR DESCRIPTION
This fixes a few inconsistencies with hashing and equality https://github.com/wickman/pystachio/pull/30. This is not directly applicable for Aurora but will be for downstream packages that try to consume schema definitions in Python 3. In any case, I have added a test to explicitly cover the assumptions in Aurora.

