### PR TITLE
Set IsProd in Scheduler

### DIFF
--- a/src/main/java/org/apache/aurora/scheduler/TierInfo.java
+++ b/src/main/java/org/apache/aurora/scheduler/TierInfo.java
@@ -20,6 +20,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMap;
 
 import org.codehaus.jackson.annotate.JsonCreator;
+import org.codehaus.jackson.annotate.JsonIgnore;
 import org.codehaus.jackson.annotate.JsonProperty;
 
 /**
@@ -56,6 +57,17 @@ public final class TierInfo {
    */
   public boolean isRevocable() {
     return revocable;
+  }
+
+  /**
+   * Checks if this tier meets the requirements to be considered a production tier:
+   * Tier must not be running on revocable resources and must not be preemptable.
+   *
+   * @return {@code true} if this tier is a production tier, {@code false} otherwise.
+   */
+  @JsonIgnore
+  public boolean isProduction() {
+    return !(revocable || preemptible);
   }
 
   /**

--- a/src/main/java/org/apache/aurora/scheduler/configuration/ConfigurationManager.java
+++ b/src/main/java/org/apache/aurora/scheduler/configuration/ConfigurationManager.java
@@ -36,6 +36,7 @@ import org.apache.aurora.gen.PercentageSlaPolicy;
 import org.apache.aurora.gen.SlaPolicy;
 import org.apache.aurora.gen.TaskConfig;
 import org.apache.aurora.gen.TaskConstraint;
+import org.apache.aurora.scheduler.TierInfo;
 import org.apache.aurora.scheduler.TierManager;
 import org.apache.aurora.scheduler.base.JobKeys;
 import org.apache.aurora.scheduler.base.UserProvidedStrings;
@@ -350,7 +351,8 @@ public class ConfigurationManager {
     }
 
     try {
-      tierManager.getTier(config);
+      TierInfo tierInfo = tierManager.getTier(config);
+      builder.setProduction(tierInfo.isProduction());
     } catch (IllegalArgumentException e) {
       throw new TaskDescriptionException(e.getMessage(), e);
     }

--- a/src/main/java/org/apache/aurora/scheduler/configuration/ConfigurationManager.java
+++ b/src/main/java/org/apache/aurora/scheduler/configuration/ConfigurationManager.java
@@ -36,7 +36,6 @@ import org.apache.aurora.gen.PercentageSlaPolicy;
 import org.apache.aurora.gen.SlaPolicy;
 import org.apache.aurora.gen.TaskConfig;
 import org.apache.aurora.gen.TaskConstraint;
-import org.apache.aurora.scheduler.TierInfo;
 import org.apache.aurora.scheduler.TierManager;
 import org.apache.aurora.scheduler.base.JobKeys;
 import org.apache.aurora.scheduler.base.UserProvidedStrings;
@@ -351,8 +350,8 @@ public class ConfigurationManager {
     }
 
     try {
-      TierInfo tierInfo = tierManager.getTier(config);
-      builder.setProduction(tierInfo.isProduction());
+      // Explicitly set the production field as it is used for Quota calculations.
+      builder.setProduction(tierManager.getTier(config).isProduction());
     } catch (IllegalArgumentException e) {
       throw new TaskDescriptionException(e.getMessage(), e);
     }

--- a/src/main/java/org/apache/aurora/scheduler/configuration/ConfigurationManager.java
+++ b/src/main/java/org/apache/aurora/scheduler/configuration/ConfigurationManager.java
@@ -343,6 +343,12 @@ public class ConfigurationManager {
       throw new TaskDescriptionException("Tier contains illegal characters: " + config.getTier());
     }
 
+    if (!config.isSetTier()) {
+      String defaultTierName = tierManager.getDefaultTierName();
+      builder.setTier(defaultTierName);
+      builder.setProduction(tierManager.getTiers().get(defaultTierName).isProduction());
+    }
+
     try {
       tierManager.getTier(config);
     } catch (IllegalArgumentException e) {

--- a/src/test/java/org/apache/aurora/scheduler/base/TaskTestUtil.java
+++ b/src/test/java/org/apache/aurora/scheduler/base/TaskTestUtil.java
@@ -81,7 +81,7 @@ public final class TaskTestUtil {
           REVOCABLE_TIER_NAME, REVOCABLE_TIER
       ));
   public static final TierManager TIER_MANAGER = new TierManager.TierManagerImpl(TIER_CONFIG);
-  public static final ThriftBackfill THRIFT_BACKFILL = new ThriftBackfill(TIER_MANAGER);
+  public static final ThriftBackfill THRIFT_BACKFILL = new ThriftBackfill();
   public static final ConfigurationManagerSettings CONFIGURATION_MANAGER_SETTINGS =
       new ConfigurationManagerSettings(
           ImmutableSet.of(_Fields.MESOS),


### PR DESCRIPTION
### Description:
isProd is a field inside the Job Configuration that was deprecated a long time ago (Aurora 0.14.0) when tiers were introduced. However, its usage in the code base [remains](https://github.com/apache/aurora/blob/master/src/main/java/org/apache/aurora/scheduler/quota/QuotaManager.java#L81).

Previously we relied on backfill to find a tier similar to the job's specifications (looked for a match in preemption and recovable).

This patch seeks to explicitly set default tier (specified in the `tiers.json` file) and add an `isProduction()` method to the `TierInfo`. The `isProduction()` field returns true only if the tier is non-revocable and not preemtable.

The patch also removes the backfill code which should not be necessary at this point.

### Testing Done:
End to end
Integration tests
