### PR TITLE
Fix failing build

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -19,3 +19,4 @@ multi_line_output=3
 forced_separate=gen
 default_section=THIRDPARTY
 not_skip=__init__.py
+combine_as_imports=True

--- a/pants.ini
+++ b/pants.ini
@@ -43,6 +43,10 @@ interpreter_constraints: CPython>=2.7,<3
 # targets in isolation
 fast: False
 
+[pytest]
+# FIXME: Workaround for https://github.com/pytest-dev/pytest/issues/4770
+# Can be dropped once we upgrade to pants 1.14.0
+requirements: pytest==3.0.7
 
 # We have some modules that have side-effects upon import, including starting a repl, so we can't
 # use python-eval to validate our BUILD deps currently.

--- a/src/main/python/apache/aurora/admin/aurora_admin.py
+++ b/src/main/python/apache/aurora/admin/aurora_admin.py
@@ -15,8 +15,7 @@
 from twitter.common import app
 from twitter.common.log.options import LogOptions
 
-from apache.aurora.admin import help as help_commands
-from apache.aurora.admin import admin, maintenance
+from apache.aurora.admin import admin, help as help_commands, maintenance
 from apache.aurora.common.auth.auth_module_manager import register_auth_module
 
 from .help import add_verbosity_options, generate_terse_usage

--- a/src/main/python/apache/aurora/client/api/updater_util.py
+++ b/src/main/python/apache/aurora/client/api/updater_util.py
@@ -16,16 +16,17 @@ import collections
 from itertools import groupby
 from operator import itemgetter
 
-from pystachio import Empty, Choice
+from pystachio import Choice, Empty
 from twitter.common import log
 
-from gen.apache.aurora.api.ttypes import JobUpdateSettings, Range
 from apache.aurora.config.schema.base import (
- BatchUpdateStrategy as PystachioBatchUpdateStrategy,
- QueueUpdateStrategy as PystachioQueueUpdateStrategy,
- VariableBatchUpdateStrategy as PystachioVariableBatchUpdateStrategy
+    BatchUpdateStrategy as PystachioBatchUpdateStrategy,
+    QueueUpdateStrategy as PystachioQueueUpdateStrategy,
+    VariableBatchUpdateStrategy as PystachioVariableBatchUpdateStrategy
 )
 from apache.aurora.config.thrift import create_update_strategy_config
+
+from gen.apache.aurora.api.ttypes import JobUpdateSettings, Range
 
 
 class UpdaterConfig(object):

--- a/src/main/python/apache/aurora/config/__init__.py
+++ b/src/main/python/apache/aurora/config/__init__.py
@@ -24,8 +24,7 @@ from apache.thermos.config.loader import ThermosTaskWrapper
 
 from .loader import AuroraConfigLoader
 from .port_resolver import PortResolver
-from .thrift import InvalidConfig as InvalidThriftConfig
-from .thrift import convert as convert_thrift
+from .thrift import InvalidConfig as InvalidThriftConfig, convert as convert_thrift
 
 __all__ = ('AuroraConfig', 'PortResolver')
 

--- a/src/main/python/apache/aurora/config/loader.py
+++ b/src/main/python/apache/aurora/config/loader.py
@@ -16,8 +16,7 @@ import hashlib
 import json
 import pkgutil
 
-from pystachio.config import Config as PystachioConfig
-from pystachio.config import FileExecutor, FilelikeExecutor
+from pystachio.config import Config as PystachioConfig, FileExecutor, FilelikeExecutor
 
 from apache.aurora.config.schema import base as base_schema
 

--- a/src/main/python/apache/aurora/config/thrift.py
+++ b/src/main/python/apache/aurora/config/thrift.py
@@ -18,23 +18,21 @@ import re
 from pystachio import Empty, Ref
 from twitter.common.lang import Compatibility
 
-from apache.aurora.config.schema.base import(
-  AppcImage as PystachioAppcImage,
-  BatchUpdateStrategy as PystachioBatchUpdateStrategy,
-  Container as PystachioContainer,
-  CoordinatorSlaPolicy as PystachioCoordinatorSlaPolicy,
-  CountSlaPolicy as PystachioCountSlaPolicy,
-  DockerImage as PystachioDockerImage,
-  PercentageSlaPolicy as PystachioPercentageSlaPolicy,
-  QueueUpdateStrategy as PystachioQueueUpdateStrategy,
-  VariableBatchUpdateStrategy as PystachioVariableBatchUpdateStrategy
-)
 from apache.aurora.config.schema.base import (
+    AppcImage as PystachioAppcImage,
+    BatchUpdateStrategy as PystachioBatchUpdateStrategy,
+    Container as PystachioContainer,
+    CoordinatorSlaPolicy as PystachioCoordinatorSlaPolicy,
+    CountSlaPolicy as PystachioCountSlaPolicy,
     Docker,
+    DockerImage as PystachioDockerImage,
     HealthCheckConfig,
     Mesos,
     MesosContext,
-    MesosTaskInstance
+    MesosTaskInstance,
+    PercentageSlaPolicy as PystachioPercentageSlaPolicy,
+    QueueUpdateStrategy as PystachioQueueUpdateStrategy,
+    VariableBatchUpdateStrategy as PystachioVariableBatchUpdateStrategy
 )
 from apache.thermos.config.loader import ThermosTaskValidator
 
@@ -62,13 +60,13 @@ from gen.apache.aurora.api.ttypes import (
     Mode,
     PartitionPolicy,
     PercentageSlaPolicy,
-    Resource,
     QueueJobUpdateStrategy,
+    Resource,
     SlaPolicy,
     TaskConfig,
     TaskConstraint,
-    VariableBatchJobUpdateStrategy,
     ValueConstraint,
+    VariableBatchJobUpdateStrategy,
     Volume
 )
 

--- a/src/main/python/apache/thermos/monitoring/process_collector_psutil.py
+++ b/src/main/python/apache/thermos/monitoring/process_collector_psutil.py
@@ -17,8 +17,7 @@
 from operator import attrgetter
 from time import time
 
-from psutil import Error as PsutilError
-from psutil import AccessDenied, NoSuchProcess, Process
+from psutil import AccessDenied, Error as PsutilError, NoSuchProcess, Process
 from twitter.common import log
 
 from .process import ProcessSample

--- a/src/test/python/apache/aurora/client/api/test_updater_util.py
+++ b/src/test/python/apache/aurora/client/api/test_updater_util.py
@@ -11,28 +11,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import unittest
 import copy
+import unittest
 
-from pytest import raises
 from pystachio import Choice
+from pytest import raises
+
+from apache.aurora.client.api import UpdaterConfig
+from apache.aurora.config.schema.base import (
+    BatchUpdateStrategy as PystachioBatchUpdateStrategy,
+    QueueUpdateStrategy as PystachioQueueUpdateStrategy,
+    UpdateConfig,
+    VariableBatchUpdateStrategy as PystachioVariableBatchUpdateStrategy
+)
 
 from gen.apache.aurora.api.ttypes import (
-  JobUpdateSettings,
-  JobUpdateStrategy,
-  VariableBatchJobUpdateStrategy,
-  BatchJobUpdateStrategy,
-  QueueJobUpdateStrategy
+    BatchJobUpdateStrategy,
+    JobUpdateSettings,
+    JobUpdateStrategy,
+    QueueJobUpdateStrategy,
+    Range,
+    VariableBatchJobUpdateStrategy
 )
-from apache.aurora.client.api import UpdaterConfig
-from apache.aurora.config.schema.base import UpdateConfig
-from apache.aurora.config.schema.base import (
-  BatchUpdateStrategy as PystachioBatchUpdateStrategy,
-  QueueUpdateStrategy as PystachioQueueUpdateStrategy,
-  VariableBatchUpdateStrategy as PystachioVariableBatchUpdateStrategy
-)
-
-from gen.apache.aurora.api.ttypes import Range
 
 
 class TestUpdaterUtil(unittest.TestCase):

--- a/src/test/python/apache/aurora/client/test_config.py
+++ b/src/test/python/apache/aurora/client/test_config.py
@@ -20,8 +20,10 @@ import pytest
 from twitter.common.contextutil import temporary_dir
 
 from apache.aurora.client import config
-from apache.aurora.client.config import get_config as get_aurora_config
-from apache.aurora.client.config import PRODUCTION_DEPRECATED_WARNING
+from apache.aurora.client.config import (
+    PRODUCTION_DEPRECATED_WARNING,
+    get_config as get_aurora_config
+)
 from apache.aurora.config import AuroraConfig
 from apache.aurora.config.loader import AuroraConfigLoader
 from apache.aurora.config.schema.base import (

--- a/src/test/python/apache/aurora/config/test_loader.py
+++ b/src/test/python/apache/aurora/config/test_loader.py
@@ -13,17 +13,16 @@
 #
 import hashlib
 import json
-import mock
 import os
 import tempfile
 from io import BytesIO
 
+import mock
 import pytest
-from twitter.common.contextutil import temporary_file, temporary_dir
+from twitter.common.contextutil import temporary_dir, temporary_file
 
 from apache.aurora.config import AuroraConfig
 from apache.aurora.config.loader import AuroraConfigLoader
-
 
 BAD_MESOS_CONFIG = """
 3 2 1 3 2 4 2 3

--- a/src/test/python/apache/aurora/config/test_thrift.py
+++ b/src/test/python/apache/aurora/config/test_thrift.py
@@ -19,13 +19,11 @@ import re
 import pytest
 
 from apache.aurora.config import AuroraConfig
-from apache.aurora.config.schema.base import CoordinatorSlaPolicy as PystachioCoordinatorSlaPolicy
-from apache.aurora.config.schema.base import CountSlaPolicy as PystachioCountSlaPolicy
-from apache.aurora.config.schema.base import PartitionPolicy as PystachioPartitionPolicy
-from apache.aurora.config.schema.base import PercentageSlaPolicy as PystachioPercentageSlaPolicy
 from apache.aurora.config.schema.base import (
     AppcImage,
     Container,
+    CoordinatorSlaPolicy as PystachioCoordinatorSlaPolicy,
+    CountSlaPolicy as PystachioCountSlaPolicy,
     Docker,
     DockerImage,
     ExecutorConfig,
@@ -35,21 +33,26 @@ from apache.aurora.config.schema.base import (
     Metadata,
     Mode,
     Parameter,
+    PartitionPolicy as PystachioPartitionPolicy,
+    PercentageSlaPolicy as PystachioPercentageSlaPolicy,
     SimpleTask,
     Volume
 )
-from apache.aurora.config.thrift import convert as convert_pystachio_to_thrift
-from apache.aurora.config.thrift import InvalidConfig, task_instance_from_job
+from apache.aurora.config.thrift import (
+    InvalidConfig,
+    convert as convert_pystachio_to_thrift,
+    task_instance_from_job
+)
 from apache.thermos.config.schema import Process, Resources, Task
 
 from gen.apache.aurora.api.constants import AURORA_EXECUTOR_NAME, GOOD_IDENTIFIER_PATTERN_PYTHON
-from gen.apache.aurora.api.ttypes import Mode as ThriftMode
 from gen.apache.aurora.api.ttypes import (
     CoordinatorSlaPolicy,
     CountSlaPolicy,
     CronCollisionPolicy,
     Identity,
     JobKey,
+    Mode as ThriftMode,
     PartitionPolicy,
     PercentageSlaPolicy,
     Resource

--- a/src/test/python/apache/aurora/executor/common/test_announcer.py
+++ b/src/test/python/apache/aurora/executor/common/test_announcer.py
@@ -18,8 +18,7 @@ import threading
 import pytest
 from kazoo.client import KazooClient
 from kazoo.exceptions import KazooException
-from kazoo.security import Permissions as KazooPermissions
-from kazoo.security import ACL, Id
+from kazoo.security import ACL, Id, Permissions as KazooPermissions
 from mock import MagicMock, call, create_autospec, patch
 from twitter.common.contextutil import temporary_file
 from twitter.common.quantity import Amount, Time


### PR DESCRIPTION
Two workaround for the failing build. Both are caused by improperly pinned dependencies of our testing infrastructure. 

* Use pytest version with Python 2 compatible requirements
* Resort according to latest isort release
