### PR TITLE
update thermos_profile cmdline

### DIFF
--- a/docs/reference/configuration-tutorial.md
+++ b/docs/reference/configuration-tutorial.md
@@ -253,14 +253,14 @@ An example for this Process is:
 
     setup_env = Process(
       name = 'setup'
-      cmdline = '''cat <<EOF > .thermos_profile
-                   export RESULT=hello
-                   EOF'''
+      cmdline = "echo '{0}' > .thermos_profile".format(
+        "\n".join(["export RESULT='hello'", "export NAME='May'"])
+      )
     )
 
     read_env = Process(
       name = 'read'
-      cmdline = 'echo $RESULT'
+      cmdline = 'echo $RESULT $NAME'
     )
 
 ## Defining Task Objects


### PR DESCRIPTION
### Description:
The code for creating the `.thermos_profile` did not work for me. It failed with the error "EOF command not found." After making this change it worked. I also added a second line to `.thermos_profile` to give an example of how it is done.


### Testing Done:
Viewed change with GitHub preview. Ran changed code on vagrant VM created in the tutorial.