### PR TITLE
Make schema_helpers.py python3 compatible

### DIFF
--- a/src/main/python/apache/thermos/config/schema_helpers.py
+++ b/src/main/python/apache/thermos/config/schema_helpers.py
@@ -17,6 +17,7 @@
 # checkstyle: noqa
 
 import itertools
+from functools import reduce
 
 from pystachio import Empty, List
 from twitter.common.lang import Compatibility
@@ -103,7 +104,7 @@ class Units(object):
   @classmethod
   def finalization_wait_max(cls, waits):
     """Return a finalization_wait that is the maximum of the inputs"""
-    return max([0] + map(cls.safe_get, waits))
+    return max([0] + [cls.safe_get(unit) for unit in waits])
 
   @classmethod
   def processes_merge(cls, tasks):


### PR DESCRIPTION
### Description:
This fixes 2 errors in the `schema_helpers.py` file to make the code Python 3 compatible.
* `reduce` was moved to `functools` and [this was backported with Python 2.6](https://docs.python.org/2.7/library/functools.html#functools.reduce).
* Replace `map` with a list comprehension, as it now returns a generator.