### PR TITLE
Add observer flag to disable resource metric collection

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -17,12 +17,16 @@
 - Users may now set a value for the URI fetcher to rename a downloaded artifact to after it
   has been downloaded.
 - Auto pause feature added to VariableBatch strategy and Batch strategy. With this feature enabled,
-  when an update is ROLLING_FORWARD, the update will automatically pause itself right before
+  when an update is `ROLLING_FORWARD`, the update will automatically pause itself right before
   a new batch is started. (This feature is being released as tested but in beta state. We are
   looking to collect feedback before we consider it fully stable.)
-- loader.load() now uses memoization on the config file path so that we only load and process
+- `loader.load()` now uses memoization on the config file path so that we only load and process
   each config file once.
 - Instances run with custom executors will no longer show links to thermos observer.
+- Add observer command line option `--disable_task_resource_collection` to disable the collection of
+  CPU, memory, and disk metrics for observed tasks. This is useful in setups where metrics cannot be
+  gathered reliable (e.g. when using PID namespaces) or when it is expensive due to hundreds of
+  active tasks per host.
 
 ### Deprecations and removals:
 

--- a/docs/reference/observer-configuration.md
+++ b/docs/reference/observer-configuration.md
@@ -23,6 +23,11 @@ Options:
   --polling_interval_secs=POLLING_INTERVAL_SECS
                         The number of seconds between observer refresh
                         attempts. [default: 5]
+  --disable_task_resource_collection
+                        Disable collection of CPU and memory statistics for
+                        each active task. Those can be expensive to collect if
+                        there are hundreds of active tasks per host. [default:
+                        False]
   --task_process_collection_interval_secs=TASK_PROCESS_COLLECTION_INTERVAL_SECS
                         The number of seconds between per task process
                         resource collections. [default: 20]

--- a/src/main/python/apache/aurora/config/BUILD
+++ b/src/main/python/apache/aurora/config/BUILD
@@ -22,7 +22,6 @@ python_library(
     '3rdparty/python:pystachio',
     '3rdparty/python:twitter.common.lang',
     'api/src/main/thrift/org/apache/aurora/gen',
-    'src/main/python/apache/aurora/common',
     'src/main/python/apache/thermos/config',
   ],
   provides = setup_py(

--- a/src/main/python/apache/aurora/tools/thermos_observer.py
+++ b/src/main/python/apache/aurora/tools/thermos_observer.py
@@ -61,6 +61,15 @@ app.add_option(
 
 
 app.add_option(
+    '--disable_task_resource_collection',
+    dest='disable_task_resource_collection',
+    default=False,
+    action='store_true',
+    help="Disable collection of CPU and memory statistics for each active task. Those can be "
+         "expensive to collect if there are hundreds of active tasks per host.")
+
+
+app.add_option(
     '--task_process_collection_interval_secs',
     dest='task_process_collection_interval_secs',
     type='int',
@@ -127,6 +136,7 @@ def initialize(options):
       path_detector,
       Amount(options.polling_interval_secs, Time.SECONDS),
       Amount(options.task_process_collection_interval_secs, Time.SECONDS),
+      disable_task_resource_collection=options.disable_task_resource_collection,
       enable_mesos_disk_collector=options.enable_mesos_disk_collector,
       disk_collector_settings=disk_collector_settings)
 

--- a/src/main/python/apache/thermos/monitoring/resource.py
+++ b/src/main/python/apache/thermos/monitoring/resource.py
@@ -308,3 +308,25 @@ class TaskResourceMonitor(ResourceMonitorBase, ExceptionalThread):
                     'process_collection_interval and disk_collection_interval.')
 
     log.debug('Stopping resource monitoring for task "%s"', self._task_id)
+
+
+class NullTaskResourceMonitor(ResourceMonitorBase):
+  """ Alternative to TaskResourceMonitor that does not collect any resource metrics at all. It can
+      be used as fast replacement for TaskResourceMonitor. It is especially useful in setups where
+      metrics cannot be gathered reliable (e.g. when using PID namespaces).
+  """
+
+  def sample(self):
+    return self.sample_at(time.time())
+
+  def sample_at(self, timestamp):
+    return timestamp, self.AggregateResourceResult(0, ProcessSample.empty(), 0)
+
+  def sample_by_process(self, process_name):
+    return ProcessSample.empty()
+
+  def start(self):
+    pass
+
+  def kill(self):
+    pass

--- a/src/test/python/apache/thermos/monitoring/test_resource.py
+++ b/src/test/python/apache/thermos/monitoring/test_resource.py
@@ -25,6 +25,7 @@ from apache.thermos.monitoring.process import ProcessSample
 from apache.thermos.monitoring.resource import (
     DiskCollectorProvider,
     HistoryProvider,
+    NullTaskResourceMonitor,
     ResourceHistory,
     ResourceMonitorBase,
     TaskResourceMonitor
@@ -154,3 +155,17 @@ class TestTaskResourceMonitor(TestCase):
       task_resource_monitor.sample_by_process('fake-process-name')
 
     assert mock_get_active_processes.mock_calls == [mock.call(task_monitor)]
+
+
+class TestNullTaskResourceMonitor(TestCase):
+  def test_null_sample(self):
+    monitor = NullTaskResourceMonitor()
+    monitor.start()
+
+    null_aggregate = (0, ProcessSample.empty(), 0)
+
+    assert monitor.sample()[1] == null_aggregate
+    assert monitor.sample_at(time())[1] == null_aggregate
+    assert monitor.sample_by_process("any_process") == ProcessSample.empty()
+
+    monitor.kill()


### PR DESCRIPTION
### Description:

Add observer command line option `--disable_task_resource_collection` to disable the collection of CPU, memory, and disk metrics for observed tasks. This is useful in setups where metrics cannot be gathered reliable (e.g. when using PID namespaces) or when it is expensive due to hundreds of active tasks per host.

Sometimes the hosts are also tightly packed with many small tasks (e.g. ~130 active tasks and ~1000 finished tasks). Even with very relaxed scrape settings of  `--task_process_collection_interval_secs=3000` and `--task_disk_collection_interval_secs=3000` it can take between 150ms-2500ms to render the observer landing page `/main`. This patch reduces this to about 100ms-150ms. 

There is no immediate downside as metrics reporting is broken anyway due to the PID namespacing: We are running our Mesos agents with enabled PID namespaces (i.e.
`--isolation='namespaces/ipc,namespaces/pid,...')`. In that mode, the PID of the same process is different within the container and outside of it. This breaks the assumption of Thermos that the executor can checkpoint a PID to disk that then can be used by the Observer to show live resource statistics for that PID.

### Testing Done:
Running in production for over a year now.