### PR TITLE
Adding flag to enable SLA aware killing for non production workloads.

### DIFF
--- a/src/main/java/org/apache/aurora/scheduler/sla/SlaManager.java
+++ b/src/main/java/org/apache/aurora/scheduler/sla/SlaManager.java
@@ -42,7 +42,6 @@ import org.apache.aurora.common.quantity.Amount;
 import org.apache.aurora.common.quantity.Time;
 import org.apache.aurora.common.stats.StatsProvider;
 import org.apache.aurora.gen.ScheduleStatus;
-import org.apache.aurora.scheduler.TierManager;
 import org.apache.aurora.scheduler.base.Query;
 import org.apache.aurora.scheduler.base.Tasks;
 import org.apache.aurora.scheduler.config.types.TimeAmount;
@@ -98,6 +97,11 @@ public class SlaManager extends AbstractIdleService {
   @interface MinRequiredInstances { }
 
   @VisibleForTesting
+  @Qualifier
+  @Target({ FIELD, PARAMETER, METHOD }) @Retention(RUNTIME)
+  @interface SlaAwareKillNonProd { }
+
+  @VisibleForTesting
   static final String TASK_PARAM = "task";
 
   private static final String ATTEMPTS_STAT_NAME = "sla_coordinator_attempts";
@@ -112,7 +116,7 @@ public class SlaManager extends AbstractIdleService {
   private final AsyncHttpClient httpClient;
   private final Striped<Lock> lock;
   private final int minRequiredInstances;
-  private final TierManager tierManager;
+  private final boolean slaAwareKillNonProd;
 
   private final AtomicLong attemptsCounter;
   private final AtomicLong successCounter;
@@ -130,14 +134,13 @@ public class SlaManager extends AbstractIdleService {
              Storage storage,
              IServerInfo serverInfo,
              @HttpClient AsyncHttpClient httpClient,
-             TierManager tierManager,
-             StatsProvider statsProvider) {
+             StatsProvider statsProvider,
+             @SlaAwareKillNonProd boolean slaAwareKillNonProd) {
 
     this.executor = requireNonNull(executor);
     this.storage = requireNonNull(storage);
     this.serverInfo = requireNonNull(serverInfo);
     this.httpClient = requireNonNull(httpClient);
-    this.tierManager = requireNonNull(tierManager);
     this.minRequiredInstances = requireNonNull(minRequiredInstances);
     this.attemptsCounter = statsProvider.makeCounter(ATTEMPTS_STAT_NAME);
     this.successCounter = statsProvider.makeCounter(SUCCESS_STAT_NAME);
@@ -169,6 +172,7 @@ public class SlaManager extends AbstractIdleService {
           }
         }
     );
+    this.slaAwareKillNonProd = slaAwareKillNonProd;
   }
 
   private long getSlaDuration(ISlaPolicy slaPolicy) {
@@ -445,8 +449,7 @@ public class SlaManager extends AbstractIdleService {
   }
 
   private boolean skipSla(IScheduledTask task, long numActive) {
-    if (!tierManager.getTier(task.getAssignedTask().getTask()).isPreemptible()
-        && !tierManager.getTier(task.getAssignedTask().getTask()).isRevocable()) {
+    if (slaAwareKillNonProd || task.getAssignedTask().getTask().isProduction()) {
       return numActive < minRequiredInstances;
     }
     return true;

--- a/src/main/java/org/apache/aurora/scheduler/sla/SlaModule.java
+++ b/src/main/java/org/apache/aurora/scheduler/sla/SlaModule.java
@@ -39,6 +39,7 @@ import org.apache.aurora.scheduler.config.types.TimeAmount;
 import org.apache.aurora.scheduler.config.validators.PositiveAmount;
 import org.apache.aurora.scheduler.sla.MetricCalculator.MetricCalculatorSettings;
 import org.apache.aurora.scheduler.sla.MetricCalculator.MetricCategory;
+import org.apache.aurora.scheduler.sla.SlaManager.SlaAwareKillNonProd;
 import org.asynchttpclient.AsyncHttpClient;
 import org.asynchttpclient.DefaultAsyncHttpClientConfig;
 import org.asynchttpclient.channel.DefaultKeepAliveStrategy;
@@ -101,6 +102,11 @@ public class SlaModule extends AbstractModule {
             + "This does not apply to jobs that have a CoordinatorSlaPolicy."
     )
     public TimeAmount maxSlaDuration = new TimeAmount(2, Time.HOURS);
+
+    @Parameter(names = "-sla_aware_kill_non_prod",
+        description = "Enables SLA awareness for drain and and update for non-production tasks",
+        arity = 1)
+    public boolean slaAwareKillNonProd = false;
   }
 
   @VisibleForTesting
@@ -148,6 +154,10 @@ public class SlaModule extends AbstractModule {
     bind(new TypeLiteral<Integer>() { })
         .annotatedWith(SlaManager.MinRequiredInstances.class)
         .toInstance(options.minRequiredInstances);
+
+    bind(new TypeLiteral<Boolean>() { })
+        .annotatedWith(SlaAwareKillNonProd.class)
+        .toInstance(options.slaAwareKillNonProd);
 
     bind(new TypeLiteral<Integer>() { })
         .annotatedWith(SlaManager.MaxParallelCoordinators.class)

--- a/src/test/java/org/apache/aurora/scheduler/config/CommandLineTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/config/CommandLineTest.java
@@ -241,6 +241,7 @@ public class CommandLineTest {
     expected.sla.slaProdMetrics = ImmutableList.of(MetricCategory.JOB_UPTIMES);
     expected.sla.slaNonProdMetrics = ImmutableList.of(MetricCategory.JOB_UPTIMES);
     expected.sla.slaRefreshInterval = TEST_TIME;
+    expected.sla.slaAwareKillNonProd = true;
     expected.webhook.webhookConfigFile = tempFile;
     expected.scheduler.maxRegistrationDelay = TEST_TIME;
     expected.scheduler.maxLeadingDuration = TEST_TIME;
@@ -326,6 +327,7 @@ public class CommandLineTest {
         "-sla_aware_action_max_batch_size=42",
         "-sla_aware_kill_retry_min_delay=42days",
         "-sla_aware_kill_retry_max_delay=42days",
+        "-sla_aware_kill_non_prod=true",
         "-task_assigner_modules=org.apache.aurora.scheduler.config.CommandLineTest$NoopModule",
         "-dlog_snapshot_interval=42days",
         "-dlog_max_entry_size=42GB",

--- a/src/test/java/org/apache/aurora/scheduler/sla/SlaManagerTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/sla/SlaManagerTest.java
@@ -135,6 +135,10 @@ public class SlaManagerTest extends EasyMockTest {
                 .annotatedWith(SlaManager.MinRequiredInstances.class)
                 .toInstance(2);
 
+            bind(new TypeLiteral<Boolean>() { })
+                .annotatedWith(SlaManager.SlaAwareKillNonProd.class)
+                .toInstance(false);
+
             bind(new TypeLiteral<Integer>() { })
                 .annotatedWith(SlaManager.MaxParallelCoordinators.class)
                 .toInstance(10);


### PR DESCRIPTION
### Description:

* Allows operators to enable SLA aware killing for non production workloads. This is turned off by default. More details can be found in the issue raised #62 


### Testing Done:
- End to end
- Unit testing