### PR TITLE
Allow configuration manager to accept non-prod jobs with SLAPolicy

### DIFF
--- a/src/main/java/org/apache/aurora/scheduler/app/AppModule.java
+++ b/src/main/java/org/apache/aurora/scheduler/app/AppModule.java
@@ -150,7 +150,8 @@ public class AppModule extends AbstractModule {
             opts.app.allowContainerVolumes,
             opts.sla.minRequiredInstances,
             opts.sla.maxSlaDuration.as(Time.SECONDS),
-            opts.app.allowedJobEnvironments),
+            opts.app.allowedJobEnvironments,
+            opts.sla.slaAwareKillNonProd),
         opts.main.driverImpl,
         opts);
   }

--- a/src/test/java/org/apache/aurora/scheduler/base/TaskTestUtil.java
+++ b/src/test/java/org/apache/aurora/scheduler/base/TaskTestUtil.java
@@ -93,7 +93,8 @@ public final class TaskTestUtil {
           true,
           2,
           1800L,
-          ConfigurationManager.DEFAULT_ALLOWED_JOB_ENVIRONMENTS);
+          ConfigurationManager.DEFAULT_ALLOWED_JOB_ENVIRONMENTS,
+          false);
   public static final ExecutorID EXECUTOR_ID = ExecutorID.newBuilder()
       .setValue("PLACEHOLDER")
       .build();

--- a/src/test/java/org/apache/aurora/scheduler/configuration/ConfigurationManagerTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/configuration/ConfigurationManagerTest.java
@@ -135,7 +135,8 @@ public class ConfigurationManagerTest {
           false,
           MIN_REQUIRED_INSTANCES,
           MAX_SLA_DURATION_SECS,
-          ConfigurationManager.DEFAULT_ALLOWED_JOB_ENVIRONMENTS),
+          ConfigurationManager.DEFAULT_ALLOWED_JOB_ENVIRONMENTS,
+          false),
       TaskTestUtil.TIER_MANAGER,
       TaskTestUtil.THRIFT_BACKFILL,
       TestExecutorSettings.THERMOS_EXECUTOR);
@@ -150,7 +151,8 @@ public class ConfigurationManagerTest {
           true,
           MIN_REQUIRED_INSTANCES,
           MAX_SLA_DURATION_SECS,
-          ConfigurationManager.DEFAULT_ALLOWED_JOB_ENVIRONMENTS),
+          ConfigurationManager.DEFAULT_ALLOWED_JOB_ENVIRONMENTS,
+          false),
       TaskTestUtil.TIER_MANAGER,
       TaskTestUtil.THRIFT_BACKFILL,
       TestExecutorSettings.THERMOS_EXECUTOR);
@@ -306,7 +308,8 @@ public class ConfigurationManagerTest {
             false,
             MIN_REQUIRED_INSTANCES,
             MAX_SLA_DURATION_SECS,
-            ConfigurationManager.DEFAULT_ALLOWED_JOB_ENVIRONMENTS),
+            ConfigurationManager.DEFAULT_ALLOWED_JOB_ENVIRONMENTS,
+            false),
         TaskTestUtil.TIER_MANAGER,
         TaskTestUtil.THRIFT_BACKFILL,
         TestExecutorSettings.THERMOS_EXECUTOR).validateAndPopulate(ITaskConfig.build(builder), 100);
@@ -332,7 +335,8 @@ public class ConfigurationManagerTest {
                     false,
                     MIN_REQUIRED_INSTANCES,
                     MAX_SLA_DURATION_SECS,
-                    ".+"),
+                    ".+",
+                false),
             TaskTestUtil.TIER_MANAGER,
             TaskTestUtil.THRIFT_BACKFILL,
             TestExecutorSettings.THERMOS_EXECUTOR)
@@ -379,11 +383,42 @@ public class ConfigurationManagerTest {
           true,
           MIN_REQUIRED_INSTANCES,
           MAX_SLA_DURATION_SECS,
-          "b.r"),
+          "b.r",
+          false),
       TaskTestUtil.TIER_MANAGER,
       TaskTestUtil.THRIFT_BACKFILL,
       TestExecutorSettings.THERMOS_EXECUTOR)
             .validateAndPopulate(IJobConfiguration.build(jobConfiguration));
+  }
+
+  @Test
+  public void testSlaPolicyNonProdTiersEnabled() throws Exception {
+    ITaskConfig config = ITaskConfig.build(
+        CONFIG_WITH_CONTAINER
+            .newBuilder()
+            .setTier(TaskTestUtil.DEV_TIER_NAME)
+            .setSlaPolicy(SlaPolicy.countSlaPolicy(
+                new CountSlaPolicy()
+                    .setCount(MIN_REQUIRED_INSTANCES - 1))));
+
+    new ConfigurationManager(
+        new ConfigurationManagerSettings(
+            ALL_CONTAINER_TYPES,
+            true,
+            ImmutableList.of(new DockerParameter("foo", "bar")),
+            false,
+            true,
+            true,
+            true,
+            MIN_REQUIRED_INSTANCES,
+            MAX_SLA_DURATION_SECS,
+            ConfigurationManager.DEFAULT_ALLOWED_JOB_ENVIRONMENTS,
+            true),
+        TaskTestUtil.TIER_MANAGER,
+        TaskTestUtil.THRIFT_BACKFILL,
+        TestExecutorSettings.THERMOS_EXECUTOR).validateAndPopulate(
+        config,
+        MIN_REQUIRED_INSTANCES);
   }
 
   @Test

--- a/src/test/java/org/apache/aurora/scheduler/configuration/ConfigurationManagerTest.java
+++ b/src/test/java/org/apache/aurora/scheduler/configuration/ConfigurationManagerTest.java
@@ -336,7 +336,7 @@ public class ConfigurationManagerTest {
                     MIN_REQUIRED_INSTANCES,
                     MAX_SLA_DURATION_SECS,
                     ".+",
-                false),
+                    false),
             TaskTestUtil.TIER_MANAGER,
             TaskTestUtil.THRIFT_BACKFILL,
             TestExecutorSettings.THERMOS_EXECUTOR)

--- a/src/test/java/org/apache/aurora/scheduler/thrift/ThriftIT.java
+++ b/src/test/java/org/apache/aurora/scheduler/thrift/ThriftIT.java
@@ -192,7 +192,8 @@ public class ThriftIT extends EasyMockTest {
         false,
         20,
         1800,
-        ConfigurationManager.DEFAULT_ALLOWED_JOB_ENVIRONMENTS);
+        ConfigurationManager.DEFAULT_ALLOWED_JOB_ENVIRONMENTS,
+        false);
 
     createThrift(configurationManagerSettings);
 


### PR DESCRIPTION
### Description:

Missed this on the original patch to enable SLA aware killing for non-prod jobs.

Currently the flag that enable non-production jobs to be drained with an SLA policy does not also allow jobs that are non production to have an SLA Policy object attached to them.

This patch modifies ConfigurationManager to allow non-production jobs to have an SLA policy attached to them.

Added a unit test to make sure the flag is working as expected.

### Testing Done:

* End to end
* Unit testing