### PR TITLE
Increasing initial timeout for health check in end to end

### DIFF
--- a/src/test/sh/org/apache/aurora/e2e/http/http_example.aurora
+++ b/src/test/sh/org/apache/aurora/e2e/http/http_example.aurora
@@ -106,7 +106,7 @@ no_python_task = SequentialTask(
 update_config = UpdateConfig(watch_secs=0, batch_size=2)
 update_config_watch_secs = UpdateConfig(watch_secs=10, batch_size=2)
 update_config_var_batch = UpdateConfig(update_strategy = VariableBatchUpdateStrategy(batch_sizes = [1,2]))
-health_check_config = HealthCheckConfig(initial_interval_secs=5, interval_secs=1)
+health_check_config = HealthCheckConfig(initial_interval_secs=10, interval_secs=1)
 shell_health_check_config = HealthCheckConfig(
   health_checker = HealthCheckerConfig(
     shell = ShellHealthChecker(shell_command='stat /usr/local/bin/run-server.sh')),


### PR DESCRIPTION
### Description:
Docker based tasks need a bit more time to come up successfully. This change allows end to end tests that were previously failing to pass.


### Testing Done:
End to end tests