### PR TITLE
Batch Auto Pause improvements

### DIFF
--- a/src/main/java/org/apache/aurora/scheduler/updater/JobUpdateControllerImpl.java
+++ b/src/main/java/org/apache/aurora/scheduler/updater/JobUpdateControllerImpl.java
@@ -639,6 +639,17 @@ class JobUpdateControllerImpl implements JobUpdateController {
   @VisibleForTesting
   static final String PULSE_TIMEOUT_MESSAGE = "Pulses from external service have timed out.";
 
+  // Determines whether it is necessary to skip evaluating a side effect if we will be pausing
+  // the update after this evaluation
+  private boolean skipSideEffect(
+      boolean pauseAfterBatch,
+      SideEffect sideEffect) {
+    return pauseAfterBatch
+        && Collections.disjoint(
+        sideEffect.getStatusChanges(),
+        InstanceUpdateStatus.TERMINAL_STATUSES);
+  }
+
   private void evaluateUpdater(
       final MutableStoreProvider storeProvider,
       final UpdateFactory.Update update,
@@ -667,18 +678,24 @@ class JobUpdateControllerImpl implements JobUpdateController {
 
     EvaluationResult<Integer> result = update.getUpdater().evaluate(changedInstance, stateProvider);
 
-    LOG.info(key + " evaluation result: " + result);
-
-    final boolean autoPauseAfterBatch =
-        isAutoPauseEnabled(instructions.getSettings().getUpdateStrategy());
-    if (autoPauseAfterBatch && maybeAutoPause(summary, result)) {
+    LOG.info("{} evaluation result: {}", key, result);
+    final boolean autoPauseAfterCurrentBatch =
+        isAutoPauseEnabled(instructions.getSettings().getUpdateStrategy())
+        && maybeAutoPause(summary, result);
+    if (autoPauseAfterCurrentBatch) {
       changeUpdateStatus(storeProvider,
           summary,
           newEvent(getPausedState(summary.getState().getStatus())).setMessage(UPDATE_AUTO_PAUSED));
-      return;
     }
 
     for (Map.Entry<Integer, SideEffect> entry : result.getSideEffects().entrySet()) {
+      // If we're pausing after processing this set of side effects, only process the side effects
+      // which are in a terminal state in order to avoid starting new shards after the pause
+      // has kicked in.
+      if (skipSideEffect(autoPauseAfterCurrentBatch, entry.getValue())) {
+        continue;
+      }
+
       Iterable<InstanceUpdateStatus> statusChanges;
 
       int instanceId = entry.getKey();
@@ -689,7 +706,7 @@ class JobUpdateControllerImpl implements JobUpdateController {
           .collect(Collectors.toList());
 
       Set<JobUpdateAction> savedActions =
-          FluentIterable.from(savedEvents).transform(EVENT_TO_ACTION).toSet();
+          savedEvents.stream().map(EVENT_TO_ACTION).collect(Collectors.toSet());
 
       // Don't bother persisting a sequence of status changes that represents an instance that
       // was immediately recognized as being healthy and in the desired state.
@@ -747,34 +764,35 @@ class JobUpdateControllerImpl implements JobUpdateController {
         }
       }
 
-      if (autoPauseAfterBatch) {
+      if (isAutoPauseEnabled(instructions.getSettings().getUpdateStrategy())) {
         instancesSeen.remove(key);
       }
       changeUpdateStatus(storeProvider, summary, event);
-    } else {
-      LOG.info("Executing side-effects for update of " + key + ": " + result.getSideEffects());
-      for (Map.Entry<Integer, SideEffect> entry : result.getSideEffects().entrySet()) {
-        IInstanceKey instance = InstanceKeys.from(key.getJob(), entry.getKey());
+      return;
+    }
 
-        Optional<InstanceAction> action = entry.getValue().getAction();
-        if (action.isPresent()) {
-          Optional<InstanceActionHandler> handler = action.get().getHandler();
-          if (handler.isPresent()) {
-            Optional<Amount<Long, Time>> reevaluateDelay = handler.get().getReevaluationDelay(
-                instance,
-                instructions,
-                storeProvider,
-                stateManager,
-                updateAgentReserver,
-                updaterStatus,
-                key,
-                slaKillController);
-            if (reevaluateDelay.isPresent()) {
-              executor.schedule(
-                  getDeferredEvaluator(instance, key),
-                  reevaluateDelay.get().getValue(),
-                  reevaluateDelay.get().getUnit().getTimeUnit());
-            }
+    LOG.info("Executing side-effects for update of {}: {}", key, result.getSideEffects().entrySet());
+    for (Map.Entry<Integer, SideEffect> entry : result.getSideEffects().entrySet()) {
+      IInstanceKey instance = InstanceKeys.from(key.getJob(), entry.getKey());
+
+      Optional<InstanceAction> action = entry.getValue().getAction();
+      if (action.isPresent() && !skipSideEffect(autoPauseAfterCurrentBatch, entry.getValue())) {
+        Optional<InstanceActionHandler> handler = action.get().getHandler();
+        if (handler.isPresent()) {
+          Optional<Amount<Long, Time>> reevaluateDelay = handler.get().getReevaluationDelay(
+              instance,
+              instructions,
+              storeProvider,
+              stateManager,
+              updateAgentReserver,
+              updaterStatus,
+              key,
+              slaKillController);
+          if (reevaluateDelay.isPresent()) {
+            executor.schedule(
+                getDeferredEvaluator(instance, key),
+                reevaluateDelay.get().getValue(),
+                reevaluateDelay.get().getUnit().getTimeUnit());
           }
         }
       }

--- a/src/main/java/org/apache/aurora/scheduler/updater/JobUpdateControllerImpl.java
+++ b/src/main/java/org/apache/aurora/scheduler/updater/JobUpdateControllerImpl.java
@@ -32,7 +32,6 @@ import com.google.common.base.Functions;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
-import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
@@ -764,14 +763,13 @@ class JobUpdateControllerImpl implements JobUpdateController {
         }
       }
 
-      if (isAutoPauseEnabled(instructions.getSettings().getUpdateStrategy())) {
-        instancesSeen.remove(key);
-      }
       changeUpdateStatus(storeProvider, summary, event);
       return;
     }
 
-    LOG.info("Executing side-effects for update of {}: {}", key, result.getSideEffects().entrySet());
+    LOG.info("Executing side-effects for update of {}: {}",
+        key,
+        result.getSideEffects().entrySet());
     for (Map.Entry<Integer, SideEffect> entry : result.getSideEffects().entrySet()) {
       IInstanceKey instance = InstanceKeys.from(key.getJob(), entry.getKey());
 
@@ -887,11 +885,9 @@ class JobUpdateControllerImpl implements JobUpdateController {
       Set<Integer> instancesCached = instancesSeen.get(key);
       Set<Integer> instancesBeingUpdated = result.getSideEffects().keySet();
 
-      // On the final batch, pause for acknowledgement and remove the cache of instances.
-      // This will cause the else branch to get run on resume and the update will finish.
       if (result.getStatus() == SUCCEEDED) {
         instancesSeen.remove(key);
-        return true;
+        return false;
       }
 
       // If the update evaluation is dealing with new instances, that signals we are at a barrier

--- a/src/main/java/org/apache/aurora/scheduler/updater/SideEffect.java
+++ b/src/main/java/org/apache/aurora/scheduler/updater/SideEffect.java
@@ -13,6 +13,7 @@
  */
 package org.apache.aurora.scheduler.updater;
 
+import com.google.common.collect.ImmutableSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -139,6 +140,8 @@ public class SideEffect {
     /**
      * The instance failed to update and is no longer being monitored.
      */
-    FAILED
+    FAILED;
+
+    public static final Set<InstanceUpdateStatus> TERMINAL_STATUSES = ImmutableSet.of(SUCCEEDED, FAILED);
   }
 }

--- a/src/main/java/org/apache/aurora/scheduler/updater/SideEffect.java
+++ b/src/main/java/org/apache/aurora/scheduler/updater/SideEffect.java
@@ -13,12 +13,12 @@
  */
 package org.apache.aurora.scheduler.updater;
 
-import com.google.common.collect.ImmutableSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
 import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableSet;
 
 import org.apache.aurora.scheduler.updater.StateEvaluator.Failure;
 
@@ -142,6 +142,7 @@ public class SideEffect {
      */
     FAILED;
 
-    public static final Set<InstanceUpdateStatus> TERMINAL_STATUSES = ImmutableSet.of(SUCCEEDED, FAILED);
+    public static final Set<InstanceUpdateStatus> TERMINAL_STATUSES =
+        ImmutableSet.of(SUCCEEDED, FAILED);
   }
 }

--- a/src/main/java/org/apache/aurora/scheduler/updater/Updates.java
+++ b/src/main/java/org/apache/aurora/scheduler/updater/Updates.java
@@ -81,7 +81,7 @@ public final class Updates {
   }
 
   /**
-   * Get the lastest {@link JobUpdateStatus} for an update.
+   * Get the latest {@link JobUpdateStatus} for an update.
    */
   static JobUpdateStatus getJobUpdateStatus(IJobUpdateDetails jobUpdateDetails) {
     return Iterables.getLast(jobUpdateDetails.getUpdateEvents()).getStatus();


### PR DESCRIPTION
### Description:
Previously there was a bug where one of the instances would not be updated before the pause kicked in. This resulted in a weird state for the update where the straggler instances (the last instance to enter a terminal state) was not evaluated until the resume was triggered.

This PR fixes this issue along with removing the final acknowledgement pause when the update as a whole has entered a terminal state. I removed this because it doesn't make much sense to pause right before the update enters a terminal state because we have other mechanisms to handle that and it complicates the code unnecessarily. If the community disagrees the feature can be added later.


### Testing Done:
Code Quality
Integration
End to End