### PR TITLE
Upgrading Mesos dependency to 1.7.2

### DIFF
--- a/3rdparty/python/BUILD
+++ b/3rdparty/python/BUILD
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 
-MESOS_REV = '1.6.1'
+MESOS_REV = '1.7.2'
 
 python_requirement_library(
   name = 'mesos.interface',

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,3 +1,9 @@
+0.23.0 (unreleased)
+======
+
+### New/updated:
+- Updated to Mesos 1.7.2.
+
 0.22.0
 ======
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,8 +22,9 @@ Vagrant.require_version ">= 2.0.2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.hostname = "aurora.local"
   # See build-support/packer/README.md for instructions on updating this box.
-  config.vm.box = "apache-aurora/dev-environment"
-  config.vm.box_version = "0.0.18"
+  #config.vm.box = "apache-aurora/dev-environment"
+  config.vm.box = "aurora-dev-env-testing"
+  #config.vm.box_version = "0.0.18"
 
   config.vm.define "devcluster" do |dev|
     dev.vm.network :private_network, ip: "192.168.33.7", :auto_config => false

--- a/build-support/packer/build.sh
+++ b/build-support/packer/build.sh
@@ -17,7 +17,7 @@ set -o errexit
 set -o nounset
 set -o verbose
 
-readonly MESOS_VERSION=1.6.1
+readonly MESOS_VERSION=1.7.2
 
 function remove_unused {
   # The default bento/ubuntu-16.04 image includes juju-core, which adds ~300 MB to our image.
@@ -28,6 +28,10 @@ function remove_unused {
 
 function install_base_packages {
   apt-get update
+  # Needed to fix a bug related to group creation which was reported for an earlier version but
+  # seems to come back from time to time.
+  # https://issues.apache.org/jira/browse/AURORA-1781
+  apt-get -y install --install-recommends linux-generic-hwe-16.04
   apt-get -y install \
       bison \
       curl \
@@ -63,7 +67,7 @@ function install_docker {
 
 function install_docker2aci {
   DOCKER2ACI_VERSION="0.17.2"
-  GOLANG_VERSION="1.11"
+  GOLANG_VERSION="1.13.5"
 
   TEMP_PATH=$(mktemp -d)
   pushd "$TEMP_PATH"

--- a/build.gradle
+++ b/build.gradle
@@ -390,7 +390,7 @@ dependencies {
   compile "org.apache.curator:curator-client:${curatorRev}"
   compile "org.apache.curator:curator-framework:${curatorRev}"
   compile "org.apache.curator:curator-recipes:${curatorRev}"
-  compile 'org.apache.mesos:mesos:1.6.1'
+  compile 'org.apache.mesos:mesos:1.7.2'
   compile "org.asynchttpclient:async-http-client:${asyncHttpclientRev}"
   compile "org.apache.shiro:shiro-guice:${shiroRev}"
   compile "org.apache.shiro:shiro-web:${shiroRev}"

--- a/src/test/sh/org/apache/aurora/e2e/test_end_to_end.sh
+++ b/src/test/sh/org/apache/aurora/e2e/test_end_to_end.sh
@@ -970,27 +970,27 @@ aurorabuild all
 setup_ssh
 setup_docker_registry
 
-#test_sla_aware_maintenance "${TEST_SLA_AWARE_MAINTENANCE_ARGS[@]}"
-#
-#test_partition_awareness "${TEST_PARTITION_AWARENESS_ARGS[@]}"
-#
-#test_version
-#test_http_example "${TEST_JOB_ARGS[@]}"
-#test_http_example "${TEST_JOB_WATCH_SECS_ARGS[@]}"
-## TODO(rdelvalle): Add verification that each batch has the right number of active instances.
-#test_http_example "${TEST_JOB_VAR_BATCH_UPDATE_ARGS[@]}"
-#test_health_check
-#
-#test_mesos_maintenance "${TEST_MAINTENANCE_JOB_ARGS[@]}"
-#
-#test_http_example_basic "${TEST_JOB_REVOCABLE_ARGS[@]}"
-#
-#test_http_example_basic "${TEST_JOB_GPU_ARGS[@]}"
-#
-#test_http_example_basic "${TEST_JOB_KILL_MESSAGE_ARGS[@]}"
-#
-#test_http_example "${TEST_JOB_DOCKER_ARGS[@]}"
-#
+test_sla_aware_maintenance "${TEST_SLA_AWARE_MAINTENANCE_ARGS[@]}"
+
+test_partition_awareness "${TEST_PARTITION_AWARENESS_ARGS[@]}"
+
+test_version
+test_http_example "${TEST_JOB_ARGS[@]}"
+test_http_example "${TEST_JOB_WATCH_SECS_ARGS[@]}"
+# TODO(rdelvalle): Add verification that each batch has the right number of active instances.
+test_http_example "${TEST_JOB_VAR_BATCH_UPDATE_ARGS[@]}"
+test_health_check
+
+test_mesos_maintenance "${TEST_MAINTENANCE_JOB_ARGS[@]}"
+
+test_http_example_basic "${TEST_JOB_REVOCABLE_ARGS[@]}"
+
+test_http_example_basic "${TEST_JOB_GPU_ARGS[@]}"
+
+test_http_example_basic "${TEST_JOB_KILL_MESSAGE_ARGS[@]}"
+
+test_http_example "${TEST_JOB_DOCKER_ARGS[@]}"
+
 
 setup_image_stores
 test_appc_unified

--- a/src/test/sh/org/apache/aurora/e2e/test_end_to_end.sh
+++ b/src/test/sh/org/apache/aurora/e2e/test_end_to_end.sh
@@ -970,27 +970,27 @@ aurorabuild all
 setup_ssh
 setup_docker_registry
 
-test_sla_aware_maintenance "${TEST_SLA_AWARE_MAINTENANCE_ARGS[@]}"
-
-test_partition_awareness "${TEST_PARTITION_AWARENESS_ARGS[@]}"
-
-test_version
-test_http_example "${TEST_JOB_ARGS[@]}"
-test_http_example "${TEST_JOB_WATCH_SECS_ARGS[@]}"
-# TODO(rdelvalle): Add verification that each batch has the right number of active instances.
-test_http_example "${TEST_JOB_VAR_BATCH_UPDATE_ARGS[@]}"
-test_health_check
-
-test_mesos_maintenance "${TEST_MAINTENANCE_JOB_ARGS[@]}"
-
-test_http_example_basic "${TEST_JOB_REVOCABLE_ARGS[@]}"
-
-test_http_example_basic "${TEST_JOB_GPU_ARGS[@]}"
-
-test_http_example_basic "${TEST_JOB_KILL_MESSAGE_ARGS[@]}"
-
-test_http_example "${TEST_JOB_DOCKER_ARGS[@]}"
-
+#test_sla_aware_maintenance "${TEST_SLA_AWARE_MAINTENANCE_ARGS[@]}"
+#
+#test_partition_awareness "${TEST_PARTITION_AWARENESS_ARGS[@]}"
+#
+#test_version
+#test_http_example "${TEST_JOB_ARGS[@]}"
+#test_http_example "${TEST_JOB_WATCH_SECS_ARGS[@]}"
+## TODO(rdelvalle): Add verification that each batch has the right number of active instances.
+#test_http_example "${TEST_JOB_VAR_BATCH_UPDATE_ARGS[@]}"
+#test_health_check
+#
+#test_mesos_maintenance "${TEST_MAINTENANCE_JOB_ARGS[@]}"
+#
+#test_http_example_basic "${TEST_JOB_REVOCABLE_ARGS[@]}"
+#
+#test_http_example_basic "${TEST_JOB_GPU_ARGS[@]}"
+#
+#test_http_example_basic "${TEST_JOB_KILL_MESSAGE_ARGS[@]}"
+#
+#test_http_example "${TEST_JOB_DOCKER_ARGS[@]}"
+#
 
 setup_image_stores
 test_appc_unified


### PR DESCRIPTION
### Description:
Upgrading Aurora's dependencies on Mesos to 1.7.2

Addresses #104 


### Testing Done:
Unit tests
End to end tests fail when creating unified containers. Specifically, this same issue shows up: https://issues.apache.org/jira/browse/AURORA-1781

Initial investigation showed that this is because the `/etc/groups` file doesn't exist in the taskf directory of the sandbox which causes the CHROOTed groupadd to fail. May need some help investigating this a bit deeper.

Creating this as a draft while work is done to fix the end to end tests.